### PR TITLE
Make `recap` an implicit namespace package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ json = [
 ]
 
 [build-system]
-requires = ["pdm-pep517>=1.0.0"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.pdm.dev-dependencies]
 tests = [


### PR DESCRIPTION
I'm starting to work on the Recap gateway. I want to keep that project separate from Recap, but share the same `recap` namespace in `from recap import...` statements. I'm using PEP420's namespaces to do this. It sounds like I just need to remove the `__init__.py` from the root to make `recap` a namespace for both `recap-core` and `recap-gateway` packages. Doing so now.