### PR TITLE
Add `create` static methods for readers

### DIFF
--- a/recap/readers/bigquery.py
+++ b/recap/readers/bigquery.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
 from google.cloud import bigquery
 
 from recap.types import (
@@ -15,7 +20,13 @@ class BigQueryReader:
     def __init__(self, client: bigquery.Client):
         self.client = client
 
-    def to_recap(self, dataset: str, table: str):
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[BigQueryReader, None, None]:
+        with bigquery.Client(**kwargs) as client:
+            yield BigQueryReader(client)
+
+    def to_recap(self, dataset: str, table: str) -> StructType:
         table_ref = self.client.dataset(dataset).table(table)
         table_obj = self.client.get_table(table_ref)
         return self._parse_fields(table_obj.schema)

--- a/recap/readers/confluent_registry.py
+++ b/recap/readers/confluent_registry.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
 from confluent_kafka.schema_registry import SchemaRegistryClient
 
 from recap.converters.avro import AvroConverter
@@ -7,12 +12,14 @@ from recap.types import StructType
 
 
 class ConfluentRegistryReader:
-    def __init__(self, registry: str | SchemaRegistryClient):
-        self.registry = (
-            SchemaRegistryClient({"url": registry})
-            if isinstance(registry, str)
-            else registry
-        )
+    def __init__(self, registry: SchemaRegistryClient):
+        self.registry = registry
+
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[ConfluentRegistryReader, None, None]:
+        with SchemaRegistryClient(**kwargs) as registry:
+            yield ConfluentRegistryReader(registry)
 
     def to_recap(self, topic: str) -> StructType:
         subject = f"{topic}-value"

--- a/recap/readers/hive_metastore.py
+++ b/recap/readers/hive_metastore.py
@@ -1,4 +1,7 @@
-from typing import Any
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Generator
 
 from pymetastore.htypes import (
     HCharType,
@@ -42,6 +45,12 @@ from recap.types import (
 class HiveMetastoreReader:
     def __init__(self, client: HMS):
         self.client = client
+
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[HiveMetastoreReader, None, None]:
+        with HMS.create(**kwargs) as client:
+            yield HiveMetastoreReader(client)
 
     def to_recap(
         self,

--- a/recap/readers/mysql.py
+++ b/recap/readers/mysql.py
@@ -1,10 +1,21 @@
-from typing import Any
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Generator
 
 from recap.readers.dbapi import DbapiReader
 from recap.types import BytesType, FloatType, IntType, RecapType, StringType
 
 
 class MysqlReader(DbapiReader):
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[MysqlReader, None, None]:
+        import mysql.connector
+
+        with mysql.connector.connect(**kwargs) as client:
+            yield MysqlReader(client)  # pyright: ignore[reportGeneralTypeIssues]
+
     def get_recap_type(self, column_props: dict[str, Any]) -> RecapType:
         data_type = column_props["DATA_TYPE"].lower()
         octet_length = column_props["CHARACTER_OCTET_LENGTH"]

--- a/recap/readers/postgresql.py
+++ b/recap/readers/postgresql.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
 from math import ceil
-from typing import Any
+from typing import Any, Generator
 
 from recap.readers.dbapi import DbapiReader
 from recap.types import BoolType, BytesType, FloatType, IntType, RecapType, StringType
@@ -8,6 +11,14 @@ MAX_FIELD_SIZE = 1073741824
 
 
 class PostgresqlReader(DbapiReader):
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[PostgresqlReader, None, None]:
+        import psycopg2
+
+        with psycopg2.connect(**kwargs) as client:
+            yield PostgresqlReader(client)
+
     def get_recap_type(self, column_props: dict[str, Any]) -> RecapType:
         data_type = column_props["DATA_TYPE"].lower()
         octet_length = column_props["CHARACTER_OCTET_LENGTH"]

--- a/recap/readers/snowflake.py
+++ b/recap/readers/snowflake.py
@@ -1,10 +1,21 @@
-from typing import Any
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Generator
 
 from recap.readers.dbapi import DbapiReader
 from recap.types import BoolType, BytesType, FloatType, IntType, RecapType, StringType
 
 
 class SnowflakeReader(DbapiReader):
+    @staticmethod
+    @contextmanager
+    def create(**kwargs) -> Generator[SnowflakeReader, None, None]:
+        import snowflake.connector
+
+        with snowflake.connector.connect(**kwargs) as client:
+            yield SnowflakeReader(client)  # pyright: ignore[reportGeneralTypeIssues]
+
     def get_recap_type(self, column_props: dict[str, Any]) -> RecapType:
         data_type = column_props["DATA_TYPE"].lower()
         octet_length = column_props["CHARACTER_OCTET_LENGTH"]


### PR DESCRIPTION
I've found it cumbersome to use Recap readers interchangeably. Each reader has different init and to_recap method parameters.

This commit adds a `create` context manager for each reader. Users can now provide kwargs to the create method, which will yield a reader (and manage closing connections).

Developers can use `create` along side Pydantic settings (which I plan to use in Recap's gateway), URLs, or any other config management system.