### PR TITLE
Update `actions/checkout@v2` to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build using Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -147,7 +147,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build using Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -173,7 +173,7 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build using Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Looks like Github is starting to complain about v2 deprecation.

Closes #382