### PR TITLE
Add `recap-core[all]` package for easy installation

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "bigquery", "hive", "json", "kafka", "proto", "style", "tests", "app"]
+groups = ["default", "bigquery", "hive", "json", "kafka", "proto", "style", "tests", "app", "all"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:791e442550eccca9760831f99f6dd4883f000e2880787d1a83a415131d2cd288"
+content_hash = "sha256:7f32fce70089d591741e3ed131d7d4abefb9fac55a61598c543a394f2e4adcef"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ app = [
     "rich>=13.5.2",
     "python-dotenv>=1.0.0",
 ]
+all = [
+    "recap-core[app,bigquery,hive,json,kafka,proto]",
+]
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
Following this PDM guidance:

https://pdm.fming.dev/latest/usage/dependency/#add-dependencies

I've added a `recap-core[all]` optional dependency group to make it easy for people to install Recap if they don't care about dependencies. I'll probably use this in the Recap Docker image as well.

PDM was giving me some grief when I did `pdm add 'recap-core[app,bigquery,...]`, so I ended up manually editing the pyproject.toml and running `pdm sync`. Hopefully that works.

Closes #376