### PR TITLE
Add PyPI publication GH workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: '3.10'
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v2
+        run: cargo install toml-cli
+
+      - name: Publish to PyPI
+        run: pdm publish
+
+      - name: Bump version
+        run: |
+          TAG_NAME=${{ github.ref }}
+          TAG_NAME=${TAG_NAME#refs/tags/}
+          NEW_VERSION=$(echo $TAG_NAME | awk -F. '{$NF++; print $1"."$2"."$NF}')
+          toml set pyproject.toml project.version "$NEW_VERSION"
+
+      - name: Commit version bump
+        uses: stefanzweifel/git-auto-commit-action@v4
+        commit_message: Bump version
+        file_pattern: pyproject.toml


### PR DESCRIPTION
I've added a `publish.yaml` to publish `recap-core` via Github actions.

Recap is automatically published when a Github release is cut using the git tag format `n.n.n` (semver). The GH action will automatically publish the package, increment the version number in pyproject.toml, and commit the change. The patch version is always incremented.