### PR TITLE
Parse database and schema from Snowflake URL

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "bigquery", "hive", "json", "kafka", "proto", "style", "tes
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:7f32fce70089d591741e3ed131d7d4abefb9fac55a61598c543a394f2e4adcef"
+content_hash = "sha256:35c94b5c58f35362dc220f2060a943ee2d222121503839dc8e149d64f57d5161"
 
 [[package]]
 name = "annotated-types"

--- a/tests/unit/clients/test_snowflake.py
+++ b/tests/unit/clients/test_snowflake.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import fakesnow
 import pytest
 import snowflake.connector
@@ -334,3 +336,19 @@ class TestSnowflakeClient:
         assert client.ls() == ["TESTDB"]
         assert client.ls("TESTDB") == ["PUBLIC"]
         assert client.ls("TESTDB", "PUBLIC") == ["TEST_TYPES"]
+
+    def test_snowflake_client_create(self):
+        with patch("snowflake.connector.connect") as mock_connect:
+            mock_connection = MagicMock()
+            mock_connect.return_value.__enter__.return_value = mock_connection
+
+            with SnowflakeClient.create(
+                host="some_account",
+                paths=("some_database", "some_schema"),
+            ) as _:
+                mock_connect.assert_called_once_with(
+                    account="some_account",
+                    database="some_database",
+                    schema="some_schema",
+                    paths=("some_database", "some_schema"),
+                )


### PR DESCRIPTION
The `SnowflakeClient.create()` method was using `host` to connect. `host` is deprecated in favor of `account`. Additionally, the db/schema in the URL path wasn't being parsed into `database` and `schema` args. I fixed all that.

I also updated `ls_catalogs` since Snowflake doesn't have a `information_schema.catalogs` view.

Closes #390