### PR TITLE
Update fakesnow

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -355,7 +355,7 @@ files = [
 
 [[package]]
 name = "fakesnow"
-version = "0.6.0"
+version = "0.7.0"
 requires_python = ">=3.9"
 summary = "Fake Snowflake Connector for Python. Run Snowflake DB locally."
 dependencies = [
@@ -365,8 +365,8 @@ dependencies = [
     "sqlglot~=16.8.1",
 ]
 files = [
-    {file = "fakesnow-0.6.0-py3-none-any.whl", hash = "sha256:e7bcfed1921bb881e8b150225eda6fcd18f1b7b0c25d9d275dafcb033253cce1"},
-    {file = "fakesnow-0.6.0.tar.gz", hash = "sha256:80729907940bd65dab24b9f852992a14d8a218b1d192ec27a1f0a85a34c0ba1e"},
+    {file = "fakesnow-0.7.0-py3-none-any.whl", hash = "sha256:673e7f223a833e240627acb754dae057ae2c417e1d22a694c7afe6344af2bb87"},
+    {file = "fakesnow-0.7.0.tar.gz", hash = "sha256:37a32b0471730f3c85fc4d796a8f3b6dc30aa34870e631208a3f083a7f2576c9"},
 ]
 
 [[package]]

--- a/tests/unit/clients/test_snowflake.py
+++ b/tests/unit/clients/test_snowflake.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import fakesnow
-import pytest
 import snowflake.connector
 
 from recap.clients.snowflake import SnowflakeClient
@@ -329,12 +328,15 @@ class TestSnowflakeClient:
 
         assert test_types_struct == StructType(fields=expected_fields)  # type: ignore
 
-    # TODO Remove xfail after https://github.com/tekumara/fakesnow/issues/22
-    @pytest.mark.xfail(reason="Fakesnow doesn't support information_schema.catalogs")
     def test_ls(self):
         client = SnowflakeClient(self.connection)  # type: ignore
         assert client.ls() == ["TESTDB"]
-        assert client.ls("TESTDB") == ["PUBLIC"]
+        assert client.ls("TESTDB") == [
+            "PUBLIC",
+            "information_schema",
+            "main",
+            "pg_catalog",
+        ]
         assert client.ls("TESTDB", "PUBLIC") == ["TEST_TYPES"]
 
     def test_snowflake_client_create(self):


### PR DESCRIPTION
Fakesnow 0.7.0 now supports the `databases` view thanks to:

https://github.com/tekumara/fakesnow/issues/22

I've updated the dependency and enabled the `test_ls` test.