### PR TITLE
Use URLs instead of `[system]/[path...]`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
 
     - name: Test with pytest
       env:
-        RECAP_SYSTEMS__PG: postgresql://postgres:password@localhost:5432/testdb
+        RECAP_URLS: '["postgresql://postgres:password@localhost:5432/testdb"]'
       run: |
         pdm run integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recap-core"
-version = "0.8.10"
+version = "0.9.0"
 description = "Recap reads and writes schemas from web services, databases, and schema registries in a standard format"
 authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -1,57 +1,33 @@
-from typing import Annotated
+from typing import Annotated, Optional
 
 import typer
 import uvicorn
 from rich import print_json
 
 from recap import commands
-from recap.settings import set_config, unset_config
 from recap.types import to_dict
 
 app = typer.Typer()
 
 
 @app.command()
-def ls(path: Annotated[str, typer.Argument(help="Path to list children of.")] = "/"):
+def ls(url: Annotated[Optional[str], typer.Argument(help="URL to parent.")] = None):
     """
-    List the children of a path.
+    List a URL's children.
     """
 
-    if children := commands.ls(path):
+    if children := commands.ls(url):
         print_json(data=children)
 
 
 @app.command()
-def schema(path: Annotated[str, typer.Argument(help="Path to get schema of.")]):
+def schema(url: Annotated[str, typer.Argument(help="URL to schema.")]):
     """
-    Get the schema of a path.
+    Get a URL's schema.
     """
 
-    if recap_struct := commands.schema(path):
+    if recap_struct := commands.schema(url):
         print_json(data=to_dict(recap_struct))
-
-
-@app.command()
-def add(
-    system: Annotated[str, typer.Argument(help="User-defined name of the system.")],
-    url: Annotated[str, typer.Argument(help="URL for the system.")],
-):
-    """
-    Add a system to the config.
-    """
-
-    set_config(f"RECAP_SYSTEMS__{system}", url)
-
-
-@app.command()
-def remove(
-    system: Annotated[str, typer.Argument(help="User-defined name of the system.")],
-):
-    """
-    Remove a system from the config.
-    """
-
-    unset_config(f"RECAP_SYSTEMS__{system}")
 
 
 @app.command()

--- a/recap/clients/confluent_registry.py
+++ b/recap/clients/confluent_registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Generator
+from typing import Any, Generator
 
 from confluent_kafka.schema_registry import SchemaRegistryClient
 
@@ -25,17 +25,45 @@ class ConfluentRegistryClient:
 
     @staticmethod
     @contextmanager
-    def create(**kwargs) -> Generator[ConfluentRegistryClient, None, None]:
+    def create(**url_args) -> Generator[ConfluentRegistryClient, None, None]:
         # Filter out kwargs that are not allowed by the SchemaRegistryClient
-        kwargs = {k: v for k, v in kwargs.items() if k in ALLOWED_ATTRS}
+        url_args = {k: v for k, v in url_args.items() if k in ALLOWED_ATTRS}
 
-        with SchemaRegistryClient(kwargs) as registry:
+        with SchemaRegistryClient(url_args) as registry:
             yield ConfluentRegistryClient(registry)
+
+    @staticmethod
+    def parse(method: str, **url_args) -> tuple[str, list[Any]]:
+        from urllib.parse import urlunparse
+
+        match method:
+            case "ls":
+                url_with_clean_scheme = (
+                    url_args["url"]
+                    .replace("http+csr://", "http://")
+                    .replace("https+csr://", "https://")
+                )
+                return (url_with_clean_scheme, [])
+            case "schema":
+                subject = url_args["paths"].pop(-1)
+                connection_url = urlunparse(
+                    [
+                        url_args.get("dialect") or url_args.get("scheme"),
+                        url_args.get("netloc"),
+                        "/".join(url_args.get("paths", [])),
+                        url_args.get("params"),
+                        url_args.get("query"),
+                        url_args.get("fragment"),
+                    ]
+                )
+                return (connection_url, [subject])
+            case _:
+                raise ValueError("Invalid method")
 
     def ls(self) -> list[str]:
         return self.registry.get_subjects()
 
-    def get_schema(self, subject: str) -> StructType:
+    def schema(self, subject: str) -> StructType:
         has_kv = subject.endswith("-key") or subject.endswith("-value")
         subject = subject if has_kv else f"{subject}-value"
         registered_schema = self.registry.get_latest_version(subject)

--- a/recap/clients/mysql.py
+++ b/recap/clients/mysql.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Generator
+from typing import Any, Generator
 
 from recap.clients.dbapi import Connection, DbapiClient
 from recap.converters.mysql import MysqlConverter
+from recap.types import StructType
 
 MYSQL_CATALOG_NAME = "def"
 
@@ -16,19 +17,46 @@ class MysqlClient(DbapiClient):
     @staticmethod
     @contextmanager
     def create(
-        paths: list[str] | None = None, **kwargs
+        paths: list[str] | None = None,
+        **url_args,
     ) -> Generator[MysqlClient, None, None]:
         import mysql.connector
         from mysql.connector.constants import DEFAULT_CONFIGURATION
 
         if paths:
-            kwargs["database"] = paths[0]
+            url_args["database"] = paths[0]
 
         # Only include kwargs that are valid for the MySQL connector
-        kwargs = {k: v for k, v in kwargs.items() if k in DEFAULT_CONFIGURATION}
+        kwargs = {k: v for k, v in url_args.items() if k in DEFAULT_CONFIGURATION}
 
         with mysql.connector.connect(**kwargs) as client:
             yield MysqlClient(client)  # type: ignore
+
+    @staticmethod
+    def parse(method: str, **url_args) -> tuple[str, list[Any]]:
+        from urllib.parse import urlunparse
+
+        paths = url_args.get("paths", [])[::-1]
+        schema = paths.pop() if paths else None
+        table = paths.pop() if paths else None
+        connection_url = urlunparse(
+            [
+                url_args.get("scheme"),
+                url_args.get("netloc"),
+                schema or "",
+                url_args.get("params"),
+                url_args.get("query"),
+                url_args.get("fragment"),
+            ]
+        )
+
+        match method:
+            case "ls":
+                return (connection_url, [schema])
+            case "schema" if schema and table:
+                return (connection_url, [schema, table])
+            case _:
+                raise ValueError("Invalid method")
 
     def ls(self, schema: str | None = None) -> list[str]:
         match schema:
@@ -38,3 +66,6 @@ class MysqlClient(DbapiClient):
                 return self.ls_tables(MYSQL_CATALOG_NAME, schema)
             case _:
                 raise ValueError("Invalid arguments")
+
+    def schema(self, schema: str, table: str) -> StructType:
+        return super().schema(MYSQL_CATALOG_NAME, schema, table)

--- a/recap/clients/postgresql.py
+++ b/recap/clients/postgresql.py
@@ -55,17 +55,17 @@ class PostgresqlClient(DbapiClient):
     @contextmanager
     def create(
         paths: list[str] | None = None,
-        **kwargs,
+        **url_args,
     ) -> Generator[PostgresqlClient, None, None]:
         import psycopg2
 
         if paths:
-            kwargs["dbname"] = paths[0]
+            url_args["dbname"] = paths[0]
 
         # Only include kwargs that are valid for PsycoPG2 parse_dsn()
-        kwargs = {k: v for k, v in kwargs.items() if k in PSYCOPG2_CONNECT_ARGS}
+        url_args = {k: v for k, v in url_args.items() if k in PSYCOPG2_CONNECT_ARGS}
 
-        with psycopg2.connect(**kwargs) as client:
+        with psycopg2.connect(**url_args) as client:
             yield PostgresqlClient(client)
 
     def ls_catalogs(self) -> list[str]:

--- a/recap/clients/snowflake.py
+++ b/recap/clients/snowflake.py
@@ -13,20 +13,20 @@ class SnowflakeClient(DbapiClient):
 
     @staticmethod
     @contextmanager
-    def create(**kwargs) -> Generator[SnowflakeClient, None, None]:
+    def create(**url_args) -> Generator[SnowflakeClient, None, None]:
         import snowflake.connector
 
         snowflake_args = {}
-        snowflake_args["account"] = kwargs.pop("host")
+        snowflake_args["account"] = url_args.pop("host")
 
-        match kwargs.get("paths"):
+        match url_args.get("paths"):
             case str(database), None:
                 snowflake_args["database"] = database
             case str(database), str(schema):
                 snowflake_args["database"] = database
                 snowflake_args["schema"] = schema
 
-        with snowflake.connector.connect(**(snowflake_args | kwargs)) as client:
+        with snowflake.connector.connect(**(snowflake_args | url_args)) as client:
             yield SnowflakeClient(client)  # type: ignore
 
     def ls_catalogs(self) -> list[str]:

--- a/recap/gateway.py
+++ b/recap/gateway.py
@@ -6,25 +6,25 @@ from recap.types import to_dict
 app = FastAPI()
 
 
-@app.get("/ls/{path:path}")
-async def ls(path: str = "/") -> list[str]:
+@app.get("/ls/{url:path}")
+async def ls(url: str | None = None) -> list[str]:
     """
-    List the children of a path.
+    List the children of a URL.
     """
 
-    children = commands.ls(path)
+    children = commands.ls(url)
     if children is not None:
         return children
-    raise HTTPException(status_code=404, detail="Path not found")
+    raise HTTPException(status_code=404, detail="URL not found")
 
 
-@app.get("/schema/{path:path}")
-async def schema(path: str) -> dict:
+@app.get("/schema/{url:path}")
+async def schema(url: str) -> dict:
     """
-    Get the schema of a path.
+    Get the schema of a URL.
     """
 
-    if recap_struct := commands.schema(path):
+    if recap_struct := commands.schema(url):
         recap_dict = to_dict(recap_struct)
         if not isinstance(recap_dict, dict):
             raise HTTPException(
@@ -32,4 +32,4 @@ async def schema(path: str) -> dict:
                 detail=f"Expected a schema dict, but got {type(recap_dict)}",
             )
         return recap_dict
-    raise HTTPException(status_code=404, detail="Path not found")
+    raise HTTPException(status_code=404, detail="URL not found")

--- a/recap/settings.py
+++ b/recap/settings.py
@@ -1,7 +1,8 @@
 import os
 from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
-from dotenv import load_dotenv, set_key, unset_key
+from dotenv import load_dotenv
 from pydantic import AnyUrl, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -24,7 +25,7 @@ touch_config()
 
 
 class RecapSettings(BaseSettings):
-    systems: dict[str, AnyUrl] = Field(default_factory=dict)
+    urls: list[AnyUrl] = Field(default_factory=list)
     model_config = SettingsConfigDict(
         # .env takes priority over CONFIG_FILE
         env_file=[CONFIG_FILE, ".env"],
@@ -34,10 +35,81 @@ class RecapSettings(BaseSettings):
         secrets_dir=SECRETS_DIR,
     )
 
+    @property
+    def safe_urls(self) -> list[str]:
+        """
+        Return a list of URLs that have the username and password removed.
+        """
 
-def set_config(key: str, val: str):
-    set_key(CONFIG_FILE, key.upper(), val)
+        safe_urls_list = []
 
+        for url in self.urls:
+            split_url = urlsplit(str(url))
+            netloc = split_url.netloc
 
-def unset_config(key: str):
-    unset_key(CONFIG_FILE, key.upper())
+            if split_url.username or split_url.password:
+                if split_url.hostname is not None:
+                    netloc = split_url.hostname
+
+                if split_url.port is not None:
+                    netloc += f":{split_url.port}"
+
+            sanitized_url = urlunsplit(
+                (
+                    split_url.scheme,
+                    netloc,
+                    split_url.path.strip("/"),
+                    split_url.query,
+                    split_url.fragment,
+                )
+            )
+
+            safe_urls_list.append(sanitized_url)
+
+        return safe_urls_list
+
+    def unsafe_url(self, url: str) -> str:
+        """
+        If scheme, host, and port match a URL in the settings, merge the unsafe
+        URL's user, pass, path, query, and fragment into the safe URL and return it.
+        """
+
+        url_split = urlsplit(url)
+
+        for unsafe_url in self.urls:
+            unsafe_url_split = urlsplit(unsafe_url.unicode_string())
+
+            if (
+                unsafe_url_split.scheme == url_split.scheme
+                and unsafe_url_split.hostname == url_split.hostname
+                and unsafe_url_split.port == url_split.port
+            ):
+                netloc = unsafe_url_split.netloc
+
+                # Merge query strings.
+                # NOTE: This doesn't work for URLs that have multiple values
+                # for the same key spanning both the unsafe and input URLs.
+                unsafe_qs = parse_qs(unsafe_url_split.query)
+                url_qs = parse_qs(url_split.query)
+                merged_qs = unsafe_qs | url_qs
+                query = urlencode(merged_qs, doseq=True)
+
+                merged_url = urlunsplit(
+                    (
+                        url_split.scheme,
+                        netloc,
+                        url_split.path.strip("/"),
+                        query,
+                        url_split.fragment or unsafe_url_split.fragment,
+                    )
+                )
+
+                # Unsplit returns a URL with a trailing colon if the URL only
+                # has a scheme. This looks weird, so include trailing double
+                # slash (e.g. bigquery: to bigquery://).
+                if merged_url == f"{url_split.scheme}:":
+                    merged_url += "//"
+
+                return merged_url
+
+        return url

--- a/tests/integration/clients/test_bigquery.py
+++ b/tests/integration/clients/test_bigquery.py
@@ -129,7 +129,7 @@ def setup_data(client):
 
 def test_primitive_types(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema("test_project", "test_dataset", "test_table")
+    recap_schema = client.schema("test_project", "test_dataset", "test_table")
     recap_fields = recap_schema.fields
 
     assert recap_fields[0] == UnionType(
@@ -249,7 +249,7 @@ def test_primitive_types(client):
 @pytest.mark.xfail(reason="BigQuery emulator does not support REQUIRED fields")
 def test_required_types(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_required",
@@ -315,7 +315,7 @@ def test_required_types(client):
 
 def test_nested_struct_record_types(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_struct",
@@ -364,7 +364,7 @@ def test_nested_struct_record_types(client):
 
 def test_repeated_types(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_repeated",
@@ -382,7 +382,7 @@ def test_repeated_types(client):
 
 def test_repeated_records(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_repeated_records",
@@ -418,7 +418,7 @@ def test_repeated_records(client):
 @pytest.mark.xfail(reason="BigQuery emulator does not support DEFAULT values")
 def test_default_value(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_default",
@@ -436,7 +436,7 @@ def test_default_value(client):
 @pytest.mark.xfail(reason="BigQuery emulator does not support OPTIONS")
 def test_column_description(client):
     client = BigQueryClient(client)
-    recap_schema = client.get_schema(
+    recap_schema = client.schema(
         "test_project",
         "test_dataset",
         "test_table_description",

--- a/tests/integration/clients/test_confluent_registry.py
+++ b/tests/integration/clients/test_confluent_registry.py
@@ -66,7 +66,7 @@ class TestConfluentRegistryClient:
 
     def test_struct_avro(self):
         client = ConfluentRegistryClient(self.schema_registry_client)
-        result = client.get_schema("dummy_topic")
+        result = client.schema("dummy_topic")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2
@@ -77,7 +77,7 @@ class TestConfluentRegistryClient:
 
     def test_struct_proto(self):
         client = ConfluentRegistryClient(self.schema_registry_client)
-        result = client.get_schema("dummy_topic_protobuf")
+        result = client.schema("dummy_topic_protobuf")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2
@@ -90,7 +90,7 @@ class TestConfluentRegistryClient:
 
     def test_struct_json(self):
         client = ConfluentRegistryClient(self.schema_registry_client)
-        result = client.get_schema("dummy_topic_json")
+        result = client.schema("dummy_topic_json")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2

--- a/tests/integration/clients/test_hive_metastore.py
+++ b/tests/integration/clients/test_hive_metastore.py
@@ -152,7 +152,7 @@ def setup_data(hive_client):
 def test_primitive_types(hive_client):
     hms = HMS(hive_client)
     client = HiveMetastoreClient(hms)
-    table = client.get_schema("test_db", "test_table2")
+    table = client.schema("test_db", "test_table2")
     fields = table.fields
 
     assert len(fields) == 13
@@ -260,7 +260,7 @@ def test_primitive_types(hive_client):
 def test_parameterized_types(hive_client):
     hms = HMS(hive_client)
     client = HiveMetastoreClient(hms)
-    table = client.get_schema("test_db", "test_table3")
+    table = client.schema("test_db", "test_table3")
     fields = table.fields
 
     assert len(fields) == 7

--- a/tests/integration/clients/test_mysql.py
+++ b/tests/integration/clients/test_mysql.py
@@ -77,7 +77,7 @@ class TestMySqlClient:
         client = MysqlClient(self.connection)  # type: ignore
 
         # Test 'test_types' table. MySQL catalog is always 'def'.
-        test_types_struct = client.get_schema("def", "testdb", "test_types")
+        test_types_struct = client.schema("testdb", "test_types")
 
         # Define the expected output for 'test_types' table
         expected_fields = [

--- a/tests/integration/clients/test_postgresql.py
+++ b/tests/integration/clients/test_postgresql.py
@@ -67,7 +67,7 @@ class TestPostgresqlClient:
         client = PostgresqlClient(self.connection)  # type: ignore
 
         # Test 'test_types' table
-        test_types_struct = client.get_schema("testdb", "public", "test_types")
+        test_types_struct = client.schema("testdb", "public", "test_types")
 
         # Define the expected output for 'test_types' table
         expected_fields = [

--- a/tests/integration/test_gateway.py
+++ b/tests/integration/test_gateway.py
@@ -67,15 +67,22 @@ class TestGateway:
     def test_ls_root(self):
         response = client.get("/ls")
         assert response.status_code == 200
-        assert response.json() == ["pg"]
+        assert response.json() == ["postgresql://localhost:5432/testdb"]
 
     def test_ls_subpath(self):
-        response = client.get("/ls/pg")
+        response = client.get("/ls/postgresql://localhost:5432/testdb")
         assert response.status_code == 200
-        assert response.json() == ["postgres", "template0", "template1", "testdb"]
+        assert response.json() == [
+            "pg_toast",
+            "pg_catalog",
+            "public",
+            "information_schema",
+        ]
 
     def test_schema(self):
-        response = client.get("/schema/pg/testdb/public/test_types")
+        response = client.get(
+            "/schema/postgresql://localhost:5432/testdb/public/test_types"
+        )
         assert response.status_code == 200
         assert response.json() == {
             "type": "struct",

--- a/tests/unit/clients/test_bigquery.py
+++ b/tests/unit/clients/test_bigquery.py
@@ -1,0 +1,48 @@
+import pytest
+
+from recap.clients.bigquery import BigQueryClient
+
+
+@pytest.mark.parametrize(
+    "method, paths, expected_result",
+    [
+        # Test ls method
+        ("ls", ["project1"], ("bigquery://", ["project1", None, None])),
+        ("ls", [], ("bigquery://", [None, None, None])),
+        (
+            "ls",
+            ["project1", "dataset1"],
+            ("bigquery://", ["project1", "dataset1", None]),
+        ),
+        (
+            "ls",
+            ["project1", "dataset1", "table1"],
+            ("bigquery://", ["project1", "dataset1", "table1"]),
+        ),
+        # Test schema method
+        ("schema", ["project2"], ("bigquery://", ["project2", None, None])),
+        (
+            "schema",
+            ["project2", "dataset2"],
+            ("bigquery://", ["project2", "dataset2", None]),
+        ),
+        (
+            "schema",
+            ["project2", "dataset2", "table2"],
+            ("bigquery://", ["project2", "dataset2", "table2"]),
+        ),
+        # Test invalid method
+        (
+            "invalid_method",
+            ["project3"],
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+    ],
+)
+def test_parse_method(method, paths, expected_result):
+    if isinstance(expected_result, tuple):
+        result = BigQueryClient.parse(method, paths)
+        assert result == expected_result
+    else:
+        with expected_result:
+            BigQueryClient.parse(method, paths)

--- a/tests/unit/clients/test_confluent_registry.py
+++ b/tests/unit/clients/test_confluent_registry.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from confluent_kafka import schema_registry
 
 from recap.clients.confluent_registry import ConfluentRegistryClient
@@ -28,7 +29,7 @@ def test_struct_avro():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     client = ConfluentRegistryClient(mock_schema_registry_client)
-    result = client.get_schema("dummy_topic-value")
+    result = client.schema("dummy_topic-value")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -64,7 +65,7 @@ def test_struct_protobuf():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     client = ConfluentRegistryClient(mock_schema_registry_client)
-    result = client.get_schema("dummy_topic-value")
+    result = client.schema("dummy_topic-value")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -108,7 +109,7 @@ def test_struct_json_schema():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     client = ConfluentRegistryClient(mock_schema_registry_client)
-    result = client.get_schema("dummy_topic-value")
+    result = client.schema("dummy_topic-value")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -122,3 +123,66 @@ def test_struct_json_schema():
     mock_schema_registry_client.get_latest_version.assert_called_with(
         "dummy_topic-value"
     )
+
+
+@pytest.mark.parametrize(
+    "method, url_args, expected_result",
+    [
+        # Test ls method
+        ("ls", {"url": "http+csr://registry-url"}, ("http://registry-url", [])),
+        (
+            "ls",
+            {
+                "url": "http+csr://registry-url/path1/path2?ssl.ca.location=/foo/bar.crt#foo",
+                "paths": ["path1", "path2"],
+                "scheme": "http+csr",
+                "dialect": "http",
+                "netloc": "registry-url",
+                "query": "ssl.ca.location=/foo/bar.crt",
+                "fragment": "foo",
+            },
+            ("http://registry-url/path1/path2?ssl.ca.location=/foo/bar.crt#foo", []),
+        ),
+        # Test schema method
+        (
+            "schema",
+            {
+                "url": "http+csr://registry-url/subject",
+                "paths": ["subject"],
+                "scheme": "http+csr",
+                "dialect": "http",
+                "netloc": "registry-url",
+            },
+            ("http://registry-url", ["subject"]),
+        ),
+        (
+            "schema",
+            {
+                "url": "http+csr://registry-url/path1/path2/subject",
+                "paths": ["path1", "path2", "subject"],
+                "scheme": "http+csr",
+                "dialect": "http",
+                "netloc": "registry-url",
+                "query": "ssl.ca.location=/foo/bar.crt",
+                "fragment": "foo",
+            },
+            (
+                "http://registry-url/path1/path2?ssl.ca.location=/foo/bar.crt#foo",
+                ["subject"],
+            ),
+        ),
+        # Test invalid method
+        (
+            "invalid_method",
+            {"url": "http+csr://registry-url"},
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+    ],
+)
+def test_parse_method(method, url_args, expected_result):
+    if isinstance(expected_result, tuple):
+        result = ConfluentRegistryClient.parse(method, **url_args)
+        assert result == expected_result
+    else:
+        with expected_result:
+            ConfluentRegistryClient.parse(method, **url_args)

--- a/tests/unit/clients/test_init.py
+++ b/tests/unit/clients/test_init.py
@@ -1,9 +1,11 @@
-from recap.clients import _parse_url
+import pytest
+
+from recap.clients import _url_to_dict, parse_url
 
 
-def test_parse_url_basic():
+def test_url_to_dict_basic():
     url = "http+csr://username:password@hostname:8080/path/to/resource?query=value"
-    result = _parse_url(url)
+    result = _url_to_dict(url)
     expected = {
         "scheme": "http+csr",
         "netloc": "username:password@hostname:8080",
@@ -26,16 +28,54 @@ def test_parse_url_basic():
     assert result == expected
 
 
-def test_parse_url_no_plus():
+def test_url_to_dict_no_plus():
     url = "https://hostname/path"
-    result = _parse_url(url)
+    result = _url_to_dict(url)
     assert result["scheme"] == "https"
     assert "dialect" not in result
     assert "driver" not in result
 
 
-def test_parse_url_multiple_query_params():
+def test_url_to_dict_multiple_query_params():
     url = "http://hostname/path?param1=value1&param2=value2&param2=value3"
-    result = _parse_url(url)
+    result = _url_to_dict(url)
     assert result["param1"] == "value1"
     assert result["param2"] == ["value2", "value3"]
+
+
+@pytest.mark.parametrize(
+    "method, url, expected_result",
+    [
+        # ls
+        (
+            "ls",
+            "bigquery://bigquery-url/path1/path2",
+            ("bigquery://", ["path1", "path2", None]),
+        ),
+        # schema
+        (
+            "schema",
+            "bigquery://bigquery-url/path1/path2/path3",
+            ("bigquery://", ["path1", "path2", "path3"]),
+        ),
+        # Example of a scheme that isn't supported
+        (
+            "ls",
+            "invalidscheme://invalid-url",
+            pytest.raises(ValueError, match="No clients available for scheme"),
+        ),
+        # Test invalid method
+        (
+            "invalid_method",
+            "bigquery://bigquery-url",
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+    ],
+)
+def test_parse_url(method, url, expected_result):
+    if isinstance(expected_result, tuple):
+        result = parse_url(method, url)
+        assert result == expected_result
+    else:
+        with expected_result:
+            parse_url(method, url)

--- a/tests/unit/clients/test_mysql.py
+++ b/tests/unit/clients/test_mysql.py
@@ -1,0 +1,47 @@
+import pytest
+
+from recap.clients.mysql import MysqlClient
+
+
+@pytest.mark.parametrize(
+    "method, url_args, expected_result",
+    [
+        # Test "ls" method with only URL (no schema)
+        (
+            "ls",
+            {"scheme": "mysql", "netloc": "mysql-url"},
+            ("mysql://mysql-url", [None]),
+        ),
+        # Test "ls" method with URL and schema
+        (
+            "ls",
+            {"scheme": "mysql", "netloc": "mysql-url", "paths": ["db1"]},
+            ("mysql://mysql-url/db1", ["db1"]),
+        ),
+        # Test "schema" method with URL, schema, and table
+        (
+            "schema",
+            {"scheme": "mysql", "netloc": "mysql-url", "paths": ["db1", "table1"]},
+            ("mysql://mysql-url/db1", ["db1", "table1"]),
+        ),
+        # Test invalid method
+        (
+            "invalid_method",
+            {"scheme": "mysql", "netloc": "mysql-url"},
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+        # Test "schema" method with insufficient paths (only schema, no table)
+        (
+            "schema",
+            {"scheme": "mysql", "netloc": "mysql-url", "paths": ["db1"]},
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+    ],
+)
+def test_parse_method(method, url_args, expected_result):
+    if isinstance(expected_result, tuple):
+        result = MysqlClient.parse(method, **url_args)
+        assert result == expected_result
+    else:
+        with expected_result:
+            MysqlClient.parse(method, **url_args)

--- a/tests/unit/clients/test_postgresql.py
+++ b/tests/unit/clients/test_postgresql.py
@@ -1,0 +1,67 @@
+import pytest
+
+from recap.clients.postgresql import PostgresqlClient
+
+
+@pytest.mark.parametrize(
+    "method, url_args, expected_result",
+    [
+        # Test "ls" method with only URL (no catalog or schema)
+        (
+            "ls",
+            {"scheme": "postgres", "netloc": "postgres-url"},
+            ("postgres://postgres-url", [None, None]),
+        ),
+        # Test "ls" method with URL and catalog
+        (
+            "ls",
+            {"scheme": "postgres", "netloc": "postgres-url", "paths": ["cat1"]},
+            ("postgres://postgres-url/cat1", ["cat1", None]),
+        ),
+        # Test "ls" method with URL, catalog, and schema
+        (
+            "ls",
+            {"scheme": "postgres", "netloc": "postgres-url", "paths": ["cat1", "sch1"]},
+            ("postgres://postgres-url/cat1", ["cat1", "sch1"]),
+        ),
+        # Test "schema" method with URL, catalog, schema, and table
+        (
+            "schema",
+            {
+                "scheme": "postgres",
+                "netloc": "postgres-url",
+                "paths": ["cat1", "sch1", "tbl1"],
+            },
+            ("postgres://postgres-url/cat1", ["cat1", "sch1", "tbl1"]),
+        ),
+        # Test invalid method
+        (
+            "invalid_method",
+            {"scheme": "postgres", "netloc": "postgres-url"},
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+        # Test "schema" method with insufficient paths (only catalog and schema, no table)
+        (
+            "schema",
+            {"scheme": "postgres", "netloc": "postgres-url", "paths": ["cat1", "sch1"]},
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+        # Test "ls" method with all paths (catalog, schema, and table)
+        (
+            "ls",
+            {
+                "scheme": "postgres",
+                "netloc": "postgres-url",
+                "paths": ["cat1", "sch1", "tbl1"],
+            },
+            pytest.raises(ValueError, match="Invalid method"),
+        ),
+    ],
+)
+def test_parse_method(method, url_args, expected_result):
+    if isinstance(expected_result, tuple):
+        result = PostgresqlClient.parse(method, **url_args)
+        assert result == expected_result
+    else:
+        with expected_result:
+            PostgresqlClient.parse(method, **url_args)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,13 +1,10 @@
 import os
 import tempfile
-from importlib import reload
 from json import loads
 from unittest.mock import patch
 
-from pydantic import AnyUrl
 from typer.testing import CliRunner
 
-import recap.settings
 from recap.cli import app
 from recap.types import IntType, StructType
 
@@ -46,22 +43,3 @@ class TestCli:
         result = runner.invoke(app, ["schema", "foo"])
         assert result.exit_code == 0
         assert loads(result.stdout) == {"type": "struct", "fields": ["int32"]}
-
-    def test_add_remove(self):
-        with patch.dict(os.environ, {"RECAP_CONFIG": self.temp_file_name}, clear=False):
-            # Reload after patching to reset CONFIG_FILE
-            reload(recap.settings)
-            from recap.settings import RecapSettings
-
-            # Test set_config
-            url = AnyUrl("scheme://user:pw@localhost:1234/db")
-            result = runner.invoke(app, ["add", "test_system", url.unicode_string()])
-            assert result.exit_code == 0
-            assert result.stdout == ""
-            assert RecapSettings().systems.get("test_system") == url
-
-            # Test unset_config
-            result = runner.invoke(app, ["remove", "test_system"])
-            assert result.exit_code == 0
-            assert result.stdout == ""
-            assert RecapSettings().systems.get("test_system") is None

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,35 +1,150 @@
-import os
-import tempfile
-from importlib import reload
-from unittest.mock import patch
+import pytest
 
-from pydantic import AnyUrl
-
-import recap.settings
+from recap.settings import RecapSettings
 
 
-class TestSettings:
-    @classmethod
-    def setup_class(cls):
-        # Create a temporary .env file for the test
-        cls.temp_file = tempfile.NamedTemporaryFile(delete=False)
-        cls.temp_file_name = cls.temp_file.name
+@pytest.mark.parametrize(
+    "input_urls, expected_output",
+    [
+        # Test with no credentials
+        (["http://example.com"], ["http://example.com"]),
+        # Test with a username
+        (["http://user@example.com"], ["http://example.com"]),
+        # Test with a username and password
+        (["http://user:pass@example.com"], ["http://example.com"]),
+        # Test with a port, username, and password
+        (["http://user:pass@example.com:8080"], ["http://example.com:8080"]),
+        # Test with multiple URLs
+        (
+            ["http://user:pass@example.com", "https://secure.site"],
+            ["http://example.com", "https://secure.site"],
+        ),
+        # Test with similar schemes but different credentials
+        (
+            ["http://user1:pass1@example.com", "http://user2:pass2@example.com"],
+            ["http://example.com", "http://example.com"],
+        ),
+        # Tests with queries
+        (["http://example.com?query=value"], ["http://example.com?query=value"]),
+        (
+            ["http://user:pass@example.com?query=value"],
+            ["http://example.com?query=value"],
+        ),
+        # Tests with fragments
+        (["http://example.com#fragment"], ["http://example.com#fragment"]),
+        (["http://user:pass@example.com#fragment"], ["http://example.com#fragment"]),
+        # Tests with queries and fragments
+        (
+            ["http://example.com?query=value#fragment"],
+            ["http://example.com?query=value#fragment"],
+        ),
+        (
+            ["http://user:pass@example.com?query=value#fragment"],
+            ["http://example.com?query=value#fragment"],
+        ),
+        # Multiple URLs with mixed properties
+        (
+            ["http://example.com?query=value", "http://user:pass@example.com#fragment"],
+            ["http://example.com?query=value", "http://example.com#fragment"],
+        ),
+    ],
+)
+def test_safe_urls(input_urls, expected_output):
+    settings = RecapSettings(urls=input_urls)
+    assert settings.safe_urls == expected_output
 
-    @classmethod
-    def teardown_class(cls):
-        # Delete the temporary .env file
-        os.unlink(cls.temp_file_name)
 
-    def test_set_and_unset_config(self):
-        with patch.dict(os.environ, {"RECAP_CONFIG": self.temp_file_name}, clear=False):
-            # Reload after patching to reset CONFIG_FILE
-            reload(recap.settings)
-            from recap.settings import RecapSettings, set_config, unset_config
-
-            # Test set_config
-            set_config("recap_systems__test_key", "foo://test_value")
-            assert RecapSettings().systems.get("test_key") == AnyUrl("foo://test_value")
-
-            # Test unset_config
-            unset_config("recap_systems__test_key")
-            assert RecapSettings().systems.get("test_key") is None
+@pytest.mark.parametrize(
+    "stored_urls, merging_url, expected_output",
+    [
+        # Basic test with scheme, host, and port match
+        (
+            ["http://user:pass@example.com"],
+            "http://example.com",
+            "http://user:pass@example.com",
+        ),
+        # Test with a different path in the merging URL
+        (
+            ["http://user:pass@example.com"],
+            "http://example.com/path",
+            "http://user:pass@example.com/path",
+        ),
+        # Test with a query in the merging URL
+        (
+            ["http://user:pass@example.com"],
+            "http://example.com?query=value",
+            "http://user:pass@example.com?query=value",
+        ),
+        # Test with a fragment in the merging URL
+        (
+            ["http://user:pass@example.com"],
+            "http://example.com#fragment",
+            "http://user:pass@example.com#fragment",
+        ),
+        # Test with both a query and a fragment in the merging URL
+        (
+            ["http://user:pass@example.com"],
+            "http://example.com?query=value#fragment",
+            "http://user:pass@example.com?query=value#fragment",
+        ),
+        # Merging query parameters from both stored and merging URL
+        (
+            ["http://user:pass@example.com?stored=query"],
+            "http://example.com?query=value",
+            "http://user:pass@example.com?stored=query&query=value",
+        ),
+        # Merging fragments from both stored and merging URL (prefer merging URL's fragment)
+        (
+            ["http://user:pass@example.com#stored_fragment"],
+            "http://example.com#fragment",
+            "http://user:pass@example.com#fragment",
+        ),
+        # No matching base URL should result in original merging URL being returned
+        (["http://different.com"], "http://example.com", "http://example.com"),
+        # Basic merging of paths
+        (
+            ["http://user:pass@example.com/path1"],
+            "http://example.com/path2",
+            "http://user:pass@example.com/path2",
+        ),
+        # Merging path and query
+        (
+            ["http://user:pass@example.com/path1?query1=value1"],
+            "http://example.com/path2?query2=value2",
+            "http://user:pass@example.com/path2?query1=value1&query2=value2",
+        ),
+        # Merging path and fragment
+        (
+            ["http://user:pass@example.com/path1#fragment1"],
+            "http://example.com/path2#fragment2",
+            "http://user:pass@example.com/path2#fragment2",
+        ),
+        # Merging path, query, and fragment
+        (
+            ["http://user:pass@example.com/path1?query1=value1#fragment1"],
+            "http://example.com/path2?query2=value2#fragment2",
+            "http://user:pass@example.com/path2?query1=value1&query2=value2#fragment2",
+        ),
+        # When both URLs have the same paths but different queries or fragments
+        (
+            ["http://user:pass@example.com/path"],
+            "http://example.com/path?query=value",
+            "http://user:pass@example.com/path?query=value",
+        ),
+        # When stored URL has a longer path than merging URL
+        (
+            ["http://user:pass@example.com/path1/path2"],
+            "http://example.com/path1",
+            "http://user:pass@example.com/path1",
+        ),
+        # When merging URL has a longer path than stored URL
+        (
+            ["http://user:pass@example.com/path1"],
+            "http://example.com/path1/path2",
+            "http://user:pass@example.com/path1/path2",
+        ),
+    ],
+)
+def test_unsafe_url(stored_urls, merging_url, expected_output):
+    settings = RecapSettings(urls=stored_urls)
+    assert settings.unsafe_url(merging_url) == expected_output


### PR DESCRIPTION
I wanted to build a `transpile` or `convert` command that would simply take in a file path and a format to convert the file to. I essentially had two options:

1. Have `transpile` use file paths and keep `ls`/`schema` as is.
2. Have `transpile` use file paths and change `ls`/`schema` to use URLs as well.

It bugged me that remote and local commands would look different. After some tinkering, I settled on (2).

`ls` and `schema` now take URLs. The concept of a system name is gone. `add` and `remove` have been removed as well.

URLs are still matched to their client using the scheme, and `create()`` is still called to create clients. But now, we first have to get the connection URL from the supplied URL--the two are not the same.

```bash
https+csr://example.com/root/path/and/subject

https+csr://example.com/root/path/and
```

In the example above, the `subject` is a param for the `ConfluentRegistryClient.schema` method. The rest is the connection URL for `ConfluentRegistryClient.create`. Each client has its own rules for how to parse the connection URL. These rules are now defined in the client's `parse` method.

The other change to be made was replacing the `RECAP_SYSTEMS` environment variable with `RECAP_URLS`. `RECAP_SYSTEMS` was a map from system name to the system's connection URL. Now, `RECAP_URLS` is a list of connection URLs. The URLs are used as base URLs that's merged with the connection URL from the supplied URL. This is useful because:

1. It allows users to configure the `user:pass` for systems so they don't have to type it in the CLI every time.
2. It allows the gateway to store `user:pass` for systems so users don't need to know them when querying the gateway for a schema.

```bash
postgres://example.com/testdb/public/test_types

RECAP_URLS='["postgres://user:pass@example.com"]'

postgres://user:pass@example.com/testdb
```