### PR TITLE
Add output format for `recap schema` and `/schema` calls

### DIFF
--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -315,6 +315,7 @@ class ProtobufConverter:
         match recap_type:
             case StructType(fields=fields):
                 assert recap_type.alias is not None, "Struct must have an alias."
+                assert "." in recap_type.alias, "Alias must have dotted package."
                 package, message_name = recap_type.alias.rsplit(".", 1)
                 field_number = 1
                 message_elements: list[MessageElement] = []

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -86,3 +86,68 @@ class TestCli:
             "type": "struct",
             "fields": [{"type": "int32", "name": "test_integer", "optional": True}],
         }
+
+    def test_schema_avro(self):
+        result = runner.invoke(
+            app,
+            [
+                "schema",
+                "postgresql://localhost:5432/testdb/public/test_types",
+                "-of=avro",
+            ],
+        )
+        assert result.exit_code == 0
+        assert loads(result.stdout) == {
+            "type": "record",
+            "fields": [
+                {"name": "test_integer", "default": None, "type": ["null", "int"]}
+            ],
+        }
+
+    def test_schema_json(self):
+        result = runner.invoke(
+            app,
+            [
+                "schema",
+                "postgresql://localhost:5432/testdb/public/test_types",
+                "-of=json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert loads(result.stdout) == {
+            "type": "object",
+            "properties": {"test_integer": {"default": None, "type": "integer"}},
+        }
+
+    @pytest.mark.skip(reason="Enable when #397 is fixed")
+    def test_schema_protobuf(self):
+        result = runner.invoke(
+            app,
+            [
+                "schema",
+                "postgresql://localhost:5432/testdb/public/test_types",
+                "-of=protobuf",
+            ],
+        )
+        assert result.exit_code == 0
+        assert (
+            result.stdout
+            == """
+TODO: Some proto schema
+"""
+        )
+
+    def test_schema_recap(self):
+        result = runner.invoke(
+            app,
+            [
+                "schema",
+                "postgresql://localhost:5432/testdb/public/test_types",
+                "-of=recap",
+            ],
+        )
+        assert result.exit_code == 0
+        assert loads(result.stdout) == {
+            "type": "struct",
+            "fields": [{"type": "int32", "name": "test_integer", "optional": True}],
+        }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from recap.cli import app
-from recap.types import IntType, StructType
+from recap.types import IntType, StructType, to_dict
 
 runner = CliRunner()
 
@@ -39,7 +39,7 @@ class TestCli:
 
     @patch("recap.commands.schema")
     def test_schema(self, mock_schema):
-        mock_schema.return_value = StructType([IntType(bits=32)])
+        mock_schema.return_value = to_dict(StructType([IntType(bits=32)]))
         result = runner.invoke(app, ["schema", "foo"])
         assert result.exit_code == 0
         assert loads(result.stdout) == {"type": "struct", "fields": ["int32"]}

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from recap.gateway import app
-from recap.types import IntType, StructType
 
 client = TestClient(app)
 
@@ -26,7 +25,7 @@ def test_ls_subpath(mock_ls):
 
 @patch("recap.commands.schema")
 def test_schema(mock_schema):
-    mock_schema.return_value = StructType([IntType(bits=32)])
+    mock_schema.return_value = {"type": "struct", "fields": ["int32"]}
     response = client.get("/schema/foo")
     expected = {"type": "struct", "fields": ["int32"]}
     assert response.status_code == 200


### PR DESCRIPTION
The CLI and gateway both support output format options. By default, the output format is still Recap, but users mauy also specify Avro, Protobuf, or JSON schema.

In the CLI, an `--output-format` or `-of` option was added.

In the gateway, the `Content-Type` header may be set to:

- `application/avro+json`
- `application/schema+json`
- `application/x-protobuf`
- `application/x-recap`