### PR TITLE
Add `strict` param to enforce RECAP_URLS for gateway

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -14,7 +14,7 @@ def ls(url: Annotated[Optional[str], typer.Argument(help="URL to parent.")] = No
     List a URL's children.
     """
 
-    if children := commands.ls(url):
+    if children := commands.ls(url, strict=False):
         print_json(data=children)
 
 
@@ -30,7 +30,7 @@ def schema(
     Get a URL's schema.
     """
 
-    struct_obj = commands.schema(url, output_format)
+    struct_obj = commands.schema(url, output_format, strict=False)
     match struct_obj:
         case dict():
             print_json(data=struct_obj)

--- a/recap/clients/__init__.py
+++ b/recap/clients/__init__.py
@@ -46,12 +46,13 @@ def create_client(url: str) -> Generator[Client, None, None]:
         raise ValueError(f"No clients available for scheme: {scheme}")
 
 
-def parse_url(method: str, url: str) -> tuple[str, list[Any]]:
+def parse_url(method: str, url: str, strict: bool = True) -> tuple[str, list[Any]]:
     """
     Parse a URL into a connection URL and a list of method arguments.
 
     :param method: Either "ls" or "schema".
     :param url: URL to parse
+    :param strict: If True, raise an error if the URL is not configured in settings.
     :return: Tuple of connection URL and list of method arguments.
     """
 
@@ -63,7 +64,7 @@ def parse_url(method: str, url: str) -> tuple[str, list[Any]]:
         module = import_module(module_path)
         client_class = getattr(module, class_name)
         connection_url, method_args = client_class.parse(method, **url_args)
-        return (settings.unsafe_url(connection_url), method_args)
+        return (settings.unsafe_url(connection_url, strict), method_args)
     else:
         raise ValueError(f"No clients available for scheme: {scheme}")
 

--- a/recap/commands.py
+++ b/recap/commands.py
@@ -25,31 +25,37 @@ FORMAT_MAP = {
 }
 
 
-def ls(url: str | None = None) -> list[str] | None:
+def ls(url: str | None = None, strict: bool = True) -> list[str] | None:
     """
     List a URL's children.
 
     :param url: URL where children are located. If `url` is None, list root URLs.
+    :param strict: If True, raise an error if the URL is not configured in settings.
     :return: List of children. Values are relative to `url`.
     """
 
     if not url:
         return settings.safe_urls
-    connection_url, method_args = parse_url("ls", url)
+    connection_url, method_args = parse_url("ls", url, strict)
     with create_client(connection_url) as client:
         return client.ls(*method_args)
 
 
-def schema(url: str, format: SchemaFormat = SchemaFormat.recap) -> dict | str:
+def schema(
+    url: str,
+    format: SchemaFormat = SchemaFormat.recap,
+    strict: bool = True,
+) -> dict | str:
     """
     Get a URL's schema.
 
     :param url: URL where schema is located.
     :param format: Schema format to convert to.
+    :param strict: If True, raise an error if the URL is not configured in settings.
     :return: Schema in the requested format (encoded as a dict or string).
     """
 
-    connection_url, method_args = parse_url("schema", url)
+    connection_url, method_args = parse_url("schema", url, strict)
     with create_client(connection_url) as client:
         recap_struct = client.schema(*method_args)
         output_obj: dict | str

--- a/tests/unit/clients/test_init.py
+++ b/tests/unit/clients/test_init.py
@@ -44,38 +44,42 @@ def test_url_to_dict_multiple_query_params():
 
 
 @pytest.mark.parametrize(
-    "method, url, expected_result",
+    "method, url, expected_result, strict",
     [
         # ls
         (
             "ls",
             "bigquery://bigquery-url/path1/path2",
             ("bigquery://", ["path1", "path2", None]),
+            False,
         ),
         # schema
         (
             "schema",
             "bigquery://bigquery-url/path1/path2/path3",
             ("bigquery://", ["path1", "path2", "path3"]),
+            False,
         ),
         # Example of a scheme that isn't supported
         (
             "ls",
             "invalidscheme://invalid-url",
             pytest.raises(ValueError, match="No clients available for scheme"),
+            False,
         ),
         # Test invalid method
         (
             "invalid_method",
             "bigquery://bigquery-url",
             pytest.raises(ValueError, match="Invalid method"),
+            False,
         ),
     ],
 )
-def test_parse_url(method, url, expected_result):
+def test_parse_url(method, url, expected_result, strict):
     if isinstance(expected_result, tuple):
-        result = parse_url(method, url)
+        result = parse_url(method, url, strict)
         assert result == expected_result
     else:
         with expected_result:
-            parse_url(method, url)
+            parse_url(method, url, strict)


### PR DESCRIPTION
The gateway has a gaping security hole. It allows users to ls/schema on arbitrary URLs using whatever credentials the gateway host might have. This is dangerous in a cloud environment where the host might be given a service account with access to systems that end users should not have access to. It also is dangerous now that we have a FilesystemClient that allows users to read the local disk.

I've fixed this by forcing the gateway to run `ls` and `schema` commands with `struct=True`. This parmater forces any URLs to be defined in the RECAP_URLS environment variable. Unknown URLs will now fail with a ValueError.

I have left the CLI with `strict=False` because the users running locally should be able to query whatever they want using the credentials they have on their machine.