### PR TITLE
Support postgresql enums

### DIFF
--- a/recap/clients/postgresql.py
+++ b/recap/clients/postgresql.py
@@ -110,7 +110,7 @@ class PostgresqlClient(DbapiClient):
                         array_agg(enumlabel) AS enum_values
                     FROM pg_catalog.pg_enum
                     GROUP BY enumtypid
-                ) enums ON enums.enumtypid = pg_type.oid
+                ) enums ON enums.enumtypid = pg_catalog.pg_type.oid
                 WHERE table_name = {self.param_style}
                     AND table_schema = {self.param_style}
                     AND table_catalog = {self.param_style}

--- a/recap/clients/postgresql.py
+++ b/recap/clients/postgresql.py
@@ -93,6 +93,8 @@ class PostgresqlClient(DbapiClient):
                     pg_attribute.attndims,
                     enums.enum_values
                 FROM information_schema.columns
+
+                -- Join to get the array dimensions
                 JOIN pg_catalog.pg_namespace
                     ON pg_catalog.pg_namespace.nspname = information_schema.columns.table_schema
                 JOIN pg_catalog.pg_class
@@ -101,6 +103,8 @@ class PostgresqlClient(DbapiClient):
                 JOIN pg_catalog.pg_attribute
                     ON pg_catalog.pg_attribute.attrelid = pg_catalog.pg_class.oid
                     AND pg_catalog.pg_attribute.attname = information_schema.columns.column_name
+
+                -- Join to get the enum values
                 LEFT JOIN pg_catalog.pg_type
                     ON pg_catalog.pg_type.oid = pg_catalog.pg_attribute.atttypid
                     AND pg_catalog.pg_type.typtype = 'e' -- Ensuring it's an enum type

--- a/recap/converters/postgresql.py
+++ b/recap/converters/postgresql.py
@@ -5,6 +5,7 @@ from recap.converters.dbapi import DbapiConverter
 from recap.types import (
     BoolType,
     BytesType,
+    EnumType,
     FloatType,
     IntType,
     ListType,
@@ -138,6 +139,10 @@ class PostgresqlConverter(DbapiConverter):
                     ),
                 )
                 self.registry.register_alias(base_type)
+        elif data_type == "user-defined" and column_props["ENUM_VALUES"]:
+            base_type = EnumType(
+                symbols=column_props["ENUM_VALUES"],
+            )
         else:
             raise ValueError(f"Unknown data type: {data_type}")
 

--- a/tests/integration/clients/test_postgresql.py
+++ b/tests/integration/clients/test_postgresql.py
@@ -280,8 +280,13 @@ class TestPostgresqlClient:
                     ),
                 ],
             ),
-            EnumType(
-                default=None, symbols=["sad", "ok", "happy"], name="test_enum_mood"
+            UnionType(
+                default=None,
+                name="test_enum_mood",
+                types=[
+                    NullType(),
+                    EnumType(default=None, symbols=["sad", "ok", "happy"]),
+                ],
             ),
         ]
         validate_results(test_types_struct, expected_fields)
@@ -463,6 +468,14 @@ class TestPostgresqlClient:
                             )
                         ),
                     ),
+                ],
+            ),
+            UnionType(
+                default=None,
+                name="test_enum_mood",
+                types=[
+                    NullType(),
+                    EnumType(default=None, symbols=["sad", "ok", "happy"]),
                 ],
             ),
         ]

--- a/tests/integration/clients/test_postgresql.py
+++ b/tests/integration/clients/test_postgresql.py
@@ -285,7 +285,7 @@ class TestPostgresqlClient:
                 name="test_enum_mood",
                 types=[
                     NullType(),
-                    EnumType(default=None, symbols=["sad", "ok", "happy"]),
+                    EnumType(symbols=["sad", "ok", "happy"]),
                 ],
             ),
         ]
@@ -475,7 +475,7 @@ class TestPostgresqlClient:
                 name="test_enum_mood",
                 types=[
                     NullType(),
-                    EnumType(default=None, symbols=["sad", "ok", "happy"]),
+                    EnumType(symbols=["sad", "ok", "happy"]),
                 ],
             ),
         ]

--- a/tests/integration/clients/test_postgresql.py
+++ b/tests/integration/clients/test_postgresql.py
@@ -40,7 +40,8 @@ class TestPostgresqlClient:
                 'ok',
                 'happy'
             );
-            """)
+            """
+        )
 
         # Create tables
         cursor.execute(
@@ -279,7 +280,9 @@ class TestPostgresqlClient:
                     ),
                 ],
             ),
-            EnumType(default=None, symbols=["sad", "ok", "happy"], name="test_enum_mood"),
+            EnumType(
+                default=None, symbols=["sad", "ok", "happy"], name="test_enum_mood"
+            ),
         ]
         validate_results(test_types_struct, expected_fields)
 

--- a/tests/unit/converters/test_postgresql.py
+++ b/tests/unit/converters/test_postgresql.py
@@ -242,18 +242,18 @@ from recap.types import (
         ),
         (
             {
-                'COLUMN_NAME': 'test_enum',
-                'DATA_TYPE': 'USER-DEFINED',
-                'CHARACTER_MAXIMUM_LENGTH': None,
-                'CHARACTER_OCTET_LENGTH': None,
-                'ENUM_VALUES': ['sad', 'ok', 'happy'],
-                'UDT_NAME': None,
-                'ATTNDIMS': 0,
+                "COLUMN_NAME": "test_enum",
+                "DATA_TYPE": "USER-DEFINED",
+                "CHARACTER_MAXIMUM_LENGTH": None,
+                "CHARACTER_OCTET_LENGTH": None,
+                "ENUM_VALUES": ["sad", "ok", "happy"],
+                "UDT_NAME": None,
+                "ATTNDIMS": 0,
             },
             EnumType(
-                symbols=['sad', 'ok', 'happy'],
+                symbols=["sad", "ok", "happy"],
             ),
-        )
+        ),
     ],
 )
 def test_postgresql_converter(column_props, expected):

--- a/tests/unit/converters/test_postgresql.py
+++ b/tests/unit/converters/test_postgresql.py
@@ -4,6 +4,7 @@ from recap.converters.postgresql import MAX_FIELD_SIZE, PostgresqlConverter
 from recap.types import (
     BoolType,
     BytesType,
+    EnumType,
     FloatType,
     IntType,
     ListType,
@@ -239,6 +240,20 @@ from recap.types import (
                 scale=0,
             ),
         ),
+        (
+            {
+                'COLUMN_NAME': 'test_enum',
+                'DATA_TYPE': 'USER-DEFINED',
+                'CHARACTER_MAXIMUM_LENGTH': None,
+                'CHARACTER_OCTET_LENGTH': None,
+                'ENUM_VALUES': ['sad', 'ok', 'happy'],
+                'UDT_NAME': None,
+                'ATTNDIMS': 0,
+            },
+            EnumType(
+                symbols=['sad', 'ok', 'happy'],
+            ),
+        )
     ],
 )
 def test_postgresql_converter(column_props, expected):


### PR DESCRIPTION
## Support postgresql enums

Adds support for postgresql enums, addressing https://github.com/recap-build/recap/issues/415.

This uses the [pg_type](https://www.postgresql.org/docs/current/catalog-pg-type.html) and [pg_enum](https://www.postgresql.org/docs/current/catalog-pg-enum.html) tables to discover the valid enum values for any columns using 

## Limitations

There are other [postgresql custom types](https://www.postgresql.org/docs/current/sql-createtype.html) that I am not attempting to support in this PR:

* composite type
* a range type
* a base type
* a shell type


## Validation

Using the enum example in the [postgres docs](https://www.postgresql.org/docs/current/datatype-enum.html), the integration test creates a new custom enum type,  uses it in the test table, and expects the recap `EnumType` to be found.

I also added a unit test for basically the same thing.
