### PR TITLE
Use docker-compose for Github CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: Test
 on:
   push:
     branches: [ main ]
-
   pull_request:
     branches: [ main ]
 
@@ -57,90 +56,43 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
 
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: testdb
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    strategy:
+      matrix:
+        python-version: ['3.10']
 
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: testdb
-          MYSQL_USER: mysql
-          MYSQL_PASSWORD: password
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping --silent"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    steps:
+    - uses: actions/checkout@v3
 
-      # TODO Waiting on https://github.com/goccy/bigquery-emulator/pull/208
-      bigquery:
-        image: ghcr.io/criccomini/bigquery-emulator:0.4.3-envvar
-        env:
-          BIGQUERY_EMULATOR_PROJECT: test_project
-          BIGQUERY_EMULATOR_DATASET: test_dataset
-        ports:
-          - 9050:9050
+    - name: Docker Compose Up
+      uses: isbang/compose-action@v1.5.1
+      with:
+        compose-file: tests/docker-compose.yml
 
-      zookeeper:
-        image: confluentinc/cp-zookeeper:latest
-        ports:
-          - 2181:2181
-        env:
-          ZOOKEEPER_CLIENT_PORT: 2181
-        options: >-
-          --health-cmd "echo ruok | nc localhost 2181"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    - name: Build using Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      kafka:
-        image: confluentinc/cp-kafka:latest
-        ports:
-          - 9092:9092
-        env:
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-        options: >-
-          --health-cmd "kafka-topics --bootstrap-server localhost:9092 --list"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    - name: Install dependencies
+      run: |
+        pip3 install pdm
+        pdm self update
+        pdm install
 
-      schema-registry:
-        image: confluentinc/cp-schema-registry:latest
-        ports:
-          - 8081:8081
-        env:
-          SCHEMA_REGISTRY_HOST_NAME: schema-registry
-          SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
-          SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
-          SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
-        options: >-
-          --health-cmd "curl -f http://schema-registry:8081/"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    - name: Test with pytest
+      env:
+        RECAP_URLS: '["postgresql://postgres:password@localhost:5432/testdb"]'
+      run: |
+        pdm run integration
 
-      hive-metastore:
-        image: ghcr.io/criccomini/hive-metastore-standalone:latest
-        ports:
-          - 9083:9083
+    - name: Docker Compose Down
+      uses: isbang/compose-action@v1.5.1
+      with:
+        compose-file: tests/docker-compose.yml
+
+  spec-tests:
+    runs-on: ubuntu-latest
+    needs: integration-tests
 
     strategy:
       matrix:
@@ -160,31 +112,6 @@ jobs:
         pdm self update
         pdm install
 
-    - name: Test with pytest
-      env:
-        RECAP_URLS: '["postgresql://postgres:password@localhost:5432/testdb"]'
+    - name: Test spec with pytest
       run: |
-        pdm run integration
-
-  spec-tests:
-    runs-on: ubuntu-latest
-    needs: integration-tests
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build using Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          pip3 install pdm
-          pdm self update
-          pdm install
-      - name: Test spec with pytest
-        run: |
-          pdm run spec
+        pdm run spec

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       retries: 5
 
   bigquery:
+    # TODO Waiting on https://github.com/goccy/bigquery-emulator/pull/208
     image: ghcr.io/criccomini/bigquery-emulator:0.4.3-envvar
     environment:
       BIGQUERY_EMULATOR_PROJECT: test_project


### PR DESCRIPTION
It's bugging me that we now have both a docker-compose.yml and an `integration-tests` section in ci.yaml. The two are identical, but different syntax. I've updated the Github workflow to use `docker compose` instead of duplicating the service logic.