### PR TITLE
Remove duplicate `docker compose` in docker-compose.yml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,11 +85,6 @@ jobs:
       run: |
         pdm run integration
 
-    - name: Docker Compose Down
-      uses: isbang/compose-action@v1.5.1
-      with:
-        compose-file: tests/docker-compose.yml
-
   spec-tests:
     runs-on: ubuntu-latest
     needs: integration-tests


### PR DESCRIPTION
I copy-pasted too much from GPT4. Managed to pull in a duplicate command. It looks like the docker action I'm using handles cleanup automatically.