### PR TITLE
Handle "type" being an array of strings in JSON schema converter

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -55,6 +55,14 @@ class RecapType:
         type_copy = RecapTypeClass(**attrs, **extra_attrs)
         return UnionType([NullType(), type_copy], **union_attrs)
 
+    def is_nullable(self) -> bool:
+        """
+        Returns True if the type is nullable.
+        :return: True if the type is nullable.
+        """
+
+        return isinstance(self, UnionType) and NullType() in self.types
+
     def validate(self) -> None:
         # Default to valid type
         pass

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -65,6 +65,72 @@ def test_all_basic_types():
     ]
 
 
+def test_nullable_types():
+    """Tests nullable types (["null", "string"]), with and without default values. Also tests that nullable properties aren't
+    made double nullable if they're not required."""
+    json_schema = """
+    {
+        "type": "object",
+        "properties": {
+            "required_nullable_no_default":  {"type": ["null", "string"]},
+            "required_nullable_with_null_default":  {"type": ["null", "string"], "default": null},
+            "required_nullable_with__default":  {"type": ["null", "string"], "default": "default_value"},
+            "nullable_no_default":  {"type": ["null", "string"]},
+            "nullable_with_null_default":  {"type": ["null", "string"], "default": null},
+            "nullable_with__default":  {"type": ["null", "string"], "default": "default_value"}
+        },
+        "required": ["required_nullable_no_default", "required_nullable_with_null_default", "required_nullable_with__default"]
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == [
+        UnionType([NullType(), StringType()], name="required_nullable_no_default"),
+        UnionType(
+            [NullType(), StringType()],
+            name="required_nullable_with_null_default",
+            default=None,
+        ),
+        UnionType(
+            [NullType(), StringType()],
+            name="required_nullable_with__default",
+            default="default_value",
+        ),
+        UnionType([NullType(), StringType()], name="nullable_no_default"),
+        UnionType(
+            [NullType(), StringType()],
+            name="nullable_with_null_default",
+            default=None,
+        ),
+        UnionType(
+            [NullType(), StringType()],
+            name="nullable_with__default",
+            default="default_value",
+        ),
+    ]
+
+
+def test_union_types():
+    json_schema = """
+    {
+        "type": "object",
+        "properties": {
+            "union":  {"type": ["null", "string", "boolean", "number"]}
+        },
+        "required": ["union"]
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == [
+        UnionType(
+            [NullType(), StringType(), BoolType(), FloatType(bits=64)], name="union"
+        ),
+    ]
+
+
 def test_nested_objects():
     json_schema = """
     {

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -74,12 +74,12 @@ def test_nullable_types():
         "properties": {
             "required_nullable_no_default":  {"type": ["null", "string"]},
             "required_nullable_with_null_default":  {"type": ["null", "string"], "default": null},
-            "required_nullable_with__default":  {"type": ["null", "string"], "default": "default_value"},
+            "required_nullable_with_default":  {"type": ["null", "string"], "default": "default_value"},
             "nullable_no_default":  {"type": ["null", "string"]},
             "nullable_with_null_default":  {"type": ["null", "string"], "default": null},
-            "nullable_with__default":  {"type": ["null", "string"], "default": "default_value"}
+            "nullable_with_default":  {"type": ["null", "string"], "default": "default_value"}
         },
-        "required": ["required_nullable_no_default", "required_nullable_with_null_default", "required_nullable_with__default"]
+        "required": ["required_nullable_no_default", "required_nullable_with_null_default", "required_nullable_with_default"]
     }
     """
     Draft202012Validator.check_schema(loads(json_schema))
@@ -94,10 +94,10 @@ def test_nullable_types():
         ),
         UnionType(
             [NullType(), StringType()],
-            name="required_nullable_with__default",
+            name="required_nullable_with_default",
             default="default_value",
         ),
-        UnionType([NullType(), StringType()], name="nullable_no_default"),
+        UnionType([NullType(), StringType()], name="nullable_no_default", default=None),
         UnionType(
             [NullType(), StringType()],
             name="nullable_with_null_default",
@@ -105,7 +105,7 @@ def test_nullable_types():
         ),
         UnionType(
             [NullType(), StringType()],
-            name="nullable_with__default",
+            name="nullable_with_default",
             default="default_value",
         ),
     ]


### PR DESCRIPTION
# Summary

Fixes https://github.com/recap-build/recap/issues/412

Updates to handle the case where a `type` in JSON schema is an array of strings, like `{"type": ["null", "string", "boolean", "number"]}`. From the [JSON schema docs](https://json-schema.org/understanding-json-schema/reference/type#type-specific-keywords)

> The type keyword may either be a string or an array:
>
> If it's a string, it is the name of one of the basic types above.
> If it is an array, it must be an array of strings, where each string is the name of one of the basic types, and each element is unique.

# Details

I added tests to make sure nullable/optional types are converted correctly, and that  properties of an object that are both not required & a union with null (`{"type": ["null", "string"]}`) are not made "double nullable".