### PR TITLE
Add SQLite client and converter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Test with pytest
       env:
-        RECAP_URLS: '["postgresql://postgres:password@localhost:5432/testdb"]'
+        RECAP_URLS: '["postgresql://postgres:password@localhost:5432/testdb", "sqlite:///file:mem1?mode=memory&cache=shared&uri=true"]'
       run: |
         pdm run integration
 

--- a/recap/clients/__init__.py
+++ b/recap/clients/__init__.py
@@ -19,6 +19,7 @@ CLIENTS = {
     "mysql": "recap.clients.mysql.MysqlClient",
     "postgresql": "recap.clients.postgresql.PostgresqlClient",
     "snowflake": "recap.clients.snowflake.SnowflakeClient",
+    "sqlite": "recap.clients.sqlite.SQLiteClient",
     "thrift+hms": "recap.clients.hive_metastore.HiveMetastoreClient",
 }
 

--- a/recap/clients/sqlite.py
+++ b/recap/clients/sqlite.py
@@ -92,7 +92,6 @@ class SQLiteClient:
         for row_cells in cursor.fetchall():
             row = dict(zip(names, row_cells))
             row = self.add_information_schema(row)
-            row = self.add_information_schema(row)
             rows.append(row)
 
         return self.converter.to_recap(rows)
@@ -119,6 +118,9 @@ class SQLiteClient:
         }
 
         # Extract precision, scale, and octet length.
+        # This regex matches the following patterns:
+        # - <type>(<param1>(, <param2>)?)
+        # param1 can be a precision or octet length, and param2 can be a scale.
         numeric_pattern = re_compile(r"(\w+)\((\d+)(?:,\s*(\d+))?\)")
         param_match = numeric_pattern.search(row["TYPE"])
 

--- a/recap/clients/sqlite.py
+++ b/recap/clients/sqlite.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from re import compile as re_compile
+from typing import Any, Generator
+
+from recap.clients.dbapi import Connection
+from recap.converters.sqlite import SQLiteAffinity, SQLiteConverter
+from recap.types import StructType
+
+SQLITE3_CONNECT_ARGS = {
+    "database",
+    "timeout",
+    "detect_types",
+    "isolation_level",
+    "check_same_thread",
+    "factory",
+    "cached_statements",
+    "uri",
+}
+
+
+class SQLiteClient:
+    def __init__(self, connection: Connection) -> None:
+        self.connection = connection
+        self.converter = SQLiteConverter()
+
+    @staticmethod
+    @contextmanager
+    def create(url: str, **url_args) -> Generator[SQLiteClient, None, None]:
+        import sqlite3
+
+        # Strip sqlite:/// URL prefix
+        url_args["database"] = url[len("sqlite:///") :]
+
+        # Only include kwargs that are valid for PsycoPG2 parse_dsn()
+        url_args = {k: v for k, v in url_args.items() if k in SQLITE3_CONNECT_ARGS}
+
+        with sqlite3.connect(**url_args) as client:
+            yield SQLiteClient(client)  # type: ignore
+
+    @staticmethod
+    def parse(method: str, **url_args) -> tuple[str, list[Any]]:
+        from urllib.parse import urlunparse
+
+        match method:
+            case "ls":
+                return (url_args["url"], [])
+            case "schema":
+                table = url_args["paths"].pop(-1)
+                connection_url = urlunparse(
+                    [
+                        url_args.get("dialect") or url_args.get("scheme"),
+                        url_args.get("netloc"),
+                        # Include / prefix for paths
+                        "/".join(url_args.get("paths", [])),
+                        url_args.get("params"),
+                        url_args.get("query"),
+                        url_args.get("fragment"),
+                    ]
+                )
+
+                # urlunsplit does not double slashes if netloc is empty. But most
+                # URLs with empty netloc should have a double slash (e.g.
+                # bigquery:// or sqlite:///some/file.db). Include an extra "/"
+                # because the root path is not included with an empty netloc
+                # and join().
+                if not url_args.get("netloc"):
+                    connection_url = connection_url.replace(":", ":///", 1)
+
+                return (connection_url, [table])
+            case _:
+                raise ValueError("Invalid method")
+
+    def ls(self) -> list[str]:
+        cursor = self.connection.cursor()
+        cursor.execute("SELECT name FROM sqlite_schema WHERE type='table'")
+        return [row[0] for row in cursor.fetchall()]
+
+    def schema(self, table: str) -> StructType:
+        cursor = self.connection.cursor()
+
+        # Validate that table exists since we want to prevent SQL injections in
+        # the PRAGMA call
+        if not self._table_exists(table):
+            raise ValueError(f"Table '{table}' does not exist in the database.")
+
+        cursor.execute(f"PRAGMA table_info({table});")
+        names = [name[0].upper() for name in cursor.description]
+        rows = []
+
+        for row_cells in cursor.fetchall():
+            row = dict(zip(names, row_cells))
+            row = self.add_information_schema(row)
+            row = self.add_information_schema(row)
+            rows.append(row)
+
+        return self.converter.to_recap(rows)
+
+    def add_information_schema(self, row: dict[str, Any]) -> dict[str, Any]:
+        """
+        SQLite does not have an INFORMATION_SCHEMA, so we need to add these
+        columns.
+
+        :param row: A row from the PRAGMA table_info() query.
+        :return: The row with the INFORMATION_SCHEMA columns added.
+        """
+
+        is_not_null = row["NOTNULL"] or row["PK"]
+
+        # Set defaults.
+        information_schema_cols = {
+            "COLUMN_NAME": row["NAME"],
+            "IS_NULLABLE": "NO" if is_not_null else "YES",
+            "COLUMN_DEFAULT": row["DFLT_VALUE"],
+            "NUMERIC_PRECISION": None,
+            "NUMERIC_SCALE": None,
+            "CHARACTER_OCTET_LENGTH": None,
+        }
+
+        # Extract precision, scale, and octet length.
+        numeric_pattern = re_compile(r"(\w+)\((\d+)(?:,\s*(\d+))?\)")
+        param_match = numeric_pattern.search(row["TYPE"])
+
+        if param_match:
+            # Extract matched values
+            base_type, precision, scale = param_match.groups()
+            base_type = base_type.upper()
+            precision = int(precision)
+            scale = int(scale) if scale else 0
+
+            match SQLiteConverter.get_affinity(base_type):
+                case SQLiteAffinity.INTEGER | SQLiteAffinity.REAL | SQLiteAffinity.NUMERIC:
+                    information_schema_cols["NUMERIC_PRECISION"] = precision
+                    information_schema_cols["NUMERIC_SCALE"] = scale
+                case SQLiteAffinity.TEXT | SQLiteAffinity.BLOB:
+                    information_schema_cols["CHARACTER_OCTET_LENGTH"] = precision
+
+        return row | information_schema_cols
+
+    def _table_exists(self, table: str) -> bool:
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        )
+        return bool(cursor.fetchone())

--- a/recap/converters/sqlite.py
+++ b/recap/converters/sqlite.py
@@ -1,0 +1,90 @@
+from enum import Enum
+from typing import Any
+
+from recap.converters.dbapi import DbapiConverter
+from recap.types import (
+    BytesType,
+    FloatType,
+    IntType,
+    NullType,
+    RecapType,
+    StringType,
+    UnionType,
+)
+
+# SQLite's maximum length is 2^31-1 bytes, or 2147483647 bytes.
+SQLITE_MAX_LENGTH = 2147483647
+
+
+class SQLiteAffinity(Enum):
+    """
+    SQLite uses column affinity to map non-STRICT table columns to values. See
+    https://www.sqlite.org/datatype3.html#type_affinity for details.
+    """
+
+    INTEGER = "integer"
+    REAL = "real"
+    TEXT = "text"
+    BLOB = "blob"
+    NUMERIC = "numeric"
+
+
+class SQLiteConverter(DbapiConverter):
+    def _parse_type(self, column_props: dict[str, Any]) -> RecapType:
+        column_name = column_props["COLUMN_NAME"]
+        column_type = column_props["TYPE"]
+        octet_length = column_props["CHARACTER_OCTET_LENGTH"]
+        precision = column_props["NUMERIC_PRECISION"]
+
+        match SQLiteConverter.get_affinity(column_type):
+            case SQLiteAffinity.INTEGER:
+                return IntType(bits=64)
+            case SQLiteAffinity.REAL:
+                if precision and precision <= 23:
+                    return FloatType(bits=32)
+                return FloatType(bits=64)
+            case SQLiteAffinity.TEXT:
+                return StringType(bytes_=octet_length or SQLITE_MAX_LENGTH)
+            case SQLiteAffinity.BLOB:
+                return BytesType(bytes_=octet_length or SQLITE_MAX_LENGTH)
+            case SQLiteAffinity.NUMERIC:
+                # NUMERIC affinity may contain values using all five storage classes
+                return UnionType(
+                    types=[
+                        NullType(),
+                        IntType(bits=64),
+                        FloatType(bits=64),
+                        StringType(bytes_=SQLITE_MAX_LENGTH),
+                        BytesType(bytes_=SQLITE_MAX_LENGTH),
+                    ]
+                )
+            case _:
+                raise ValueError(
+                    f"Unsupported `{column_type}` type for `{column_name}`"
+                )
+
+    @staticmethod
+    def get_affinity(column_type: str | None) -> SQLiteAffinity:
+        """
+        Encode affinity rules as defined here:
+
+        https://www.sqlite.org/datatype3.html#determination_of_column_affinity
+
+        :param column_type: The column type to determine the affinity of.
+        :return: The affinity of the column type.
+        """
+
+        column_type = (column_type or "").upper()
+
+        if not column_type:
+            return SQLiteAffinity.BLOB
+        elif "INT" in column_type:
+            return SQLiteAffinity.INTEGER
+        elif "CHAR" in column_type or "TEXT" in column_type or "CLOB" in column_type:
+            return SQLiteAffinity.TEXT
+        elif "BLOB" in column_type:
+            return SQLiteAffinity.BLOB
+        elif "REAL" in column_type or "FLOA" in column_type or "DOUB" in column_type:
+            return SQLiteAffinity.REAL
+        else:
+            return SQLiteAffinity.NUMERIC

--- a/recap/settings.py
+++ b/recap/settings.py
@@ -58,11 +58,17 @@ class RecapSettings(BaseSettings):
                 (
                     split_url.scheme,
                     netloc,
-                    split_url.path.strip("/"),
+                    split_url.path.rstrip("/"),
                     split_url.query,
                     split_url.fragment,
                 )
             )
+
+            # urlunsplit does not double slashes if netloc is empty. But most
+            # URLs with empty netloc should have a double slash (e.g.
+            # bigquery:// or sqlite:///some/file.db).
+            if not netloc:
+                sanitized_url = sanitized_url.replace(":", "://", 1)
 
             safe_urls_list.append(sanitized_url)
 
@@ -107,17 +113,17 @@ class RecapSettings(BaseSettings):
                     (
                         url_split.scheme,
                         netloc,
-                        url_path.strip("/"),
+                        url_path.rstrip("/"),
                         query,
                         url_split.fragment or unsafe_url_split.fragment,
                     )
                 )
 
-                # Unsplit returns a URL with a trailing colon if the URL only
-                # has a scheme. This looks weird, so include trailing double
-                # slash (e.g. bigquery: to bigquery://).
-                if merged_url == f"{url_split.scheme}:":
-                    merged_url += "//"
+                # urlunsplit does not double slashes if netloc is empty. But most
+                # URLs with empty netloc should have a double slash (e.g.
+                # bigquery:// or sqlite:///some/file.db).
+                if not netloc:
+                    merged_url = merged_url.replace(":", "://", 1)
 
                 return merged_url
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -86,6 +86,6 @@ services:
       retries: 5
 
   hive-metastore:
-    image: ghcr.io/criccomini/hive-metastore-standalone:latest
+    image: ghcr.io/recap-build/hive-metastore-standalone:latest
     ports:
       - "9083:9083"

--- a/tests/integration/server/test_gateway.py
+++ b/tests/integration/server/test_gateway.py
@@ -68,7 +68,10 @@ class TestGateway:
     def test_ls_root(self):
         response = client.get("/ls")
         assert response.status_code == 200
-        assert response.json() == ["postgresql://localhost:5432/testdb"]
+        assert response.json() == [
+            "postgresql://localhost:5432/testdb",
+            "sqlite:///file:mem1?mode=memory&cache=shared&uri=true",
+        ]
 
     def test_ls_subpath(self):
         response = client.get("/ls/postgresql://localhost:5432/testdb")

--- a/tests/unit/clients/test_sqlite.py
+++ b/tests/unit/clients/test_sqlite.py
@@ -1,0 +1,195 @@
+import sqlite3
+from typing import Generator
+
+import pytest
+
+from recap.clients.sqlite import SQLiteClient
+from recap.types import (
+    BytesType,
+    FloatType,
+    IntType,
+    NullType,
+    StringType,
+    StructType,
+    UnionType,
+)
+
+
+@pytest.fixture
+def sqlite_client() -> Generator[SQLiteClient, None, None]:
+    with sqlite3.connect(":memory:") as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS test_affinities (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                short_name CHAR(20) NOT NULL,
+                variable_name VARCHAR(255) NOT NULL,
+                descriptive_text CLOB NOT NULL,
+                balance REAL,
+                small_balance REAL(5, 2),
+                small_dollars FLOAT(5),
+                significant_figures DOUBLE,
+                data BLOB,
+                small_data BLOB(255),
+                custom_type FOO,
+                date_col DATE NOT NULL,
+                datetime_col DATETIME NOT NULL,
+                time_col TIME NOT NULL,
+                timestamp_col TIMESTAMP NOT NULL
+            );
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS test_strict (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                age INT NOT NULL,
+                balance REAL NOT NULL,
+                data BLOB NOT NULL,
+                anything ANY,
+                nullable_int INT
+            ) STRICT;
+            """
+        )
+        connection.commit()
+        yield SQLiteClient(connection)  # type: ignore
+
+
+def test_schema_affinities(sqlite_client: SQLiteClient):
+    schema = sqlite_client.schema("test_affinities")
+
+    expected_schema = StructType(
+        fields=[
+            IntType(bits=64, signed=True, name="id"),
+            StringType(bytes_=2147483647, name="name", variable=True),
+            StringType(bytes_=20, name="short_name", variable=True),
+            StringType(bytes_=255, name="variable_name", variable=True),
+            StringType(bytes_=2147483647, name="descriptive_text", variable=True),
+            UnionType(
+                types=[NullType(), FloatType(bits=64)],
+                name="balance",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), FloatType(bits=32)],
+                name="small_balance",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), FloatType(bits=32)],
+                name="small_dollars",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), FloatType(bits=64)],
+                name="significant_figures",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), BytesType(bytes_=2147483647)],
+                name="data",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), BytesType(bytes_=255)],
+                name="small_data",
+                default=None,
+            ),
+            UnionType(
+                default=None,
+                name="custom_type",
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+            ),
+            UnionType(
+                name="date_col",
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+            ),
+            UnionType(
+                name="datetime_col",
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+            ),
+            UnionType(
+                name="time_col",
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+            ),
+            UnionType(
+                name="timestamp_col",
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+            ),
+        ]
+    )
+
+    assert len(schema.fields) == len(expected_schema.fields)
+    for field, expected_field in zip(schema.fields, expected_schema.fields):
+        assert field == expected_field
+
+
+def test_schemas_strict(sqlite_client: SQLiteClient):
+    schema = sqlite_client.schema("test_strict")
+
+    expected_schema = StructType(
+        fields=[
+            IntType(bits=64, signed=True, name="id"),
+            StringType(bytes_=2147483647, name="name", variable=True),
+            IntType(bits=64, signed=True, name="age"),
+            FloatType(bits=64, name="balance"),
+            BytesType(bytes_=2147483647, name="data"),
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ],
+                name="anything",
+                default=None,
+            ),
+            UnionType(
+                types=[NullType(), IntType(bits=64)],
+                name="nullable_int",
+                default=None,
+            ),
+        ]
+    )
+
+    assert len(schema.fields) == len(expected_schema.fields)
+    for field, expected_field in zip(schema.fields, expected_schema.fields):
+        assert field == expected_field
+
+
+def test_ls(sqlite_client: SQLiteClient):
+    assert set(sqlite_client.ls()) == {"test_affinities", "test_strict"}

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -58,7 +58,7 @@ def test_all_basic_types():
             default=None,
         ),
         UnionType(
-            [NullType(), NullType()],
+            [NullType()],
             name="a_null",
             default=None,
         ),

--- a/tests/unit/converters/test_sqlite.py
+++ b/tests/unit/converters/test_sqlite.py
@@ -1,0 +1,238 @@
+import pytest
+
+from recap.converters.sqlite import SQLiteConverter
+from recap.types import BytesType, FloatType, IntType, NullType, StringType, UnionType
+
+
+# Test cases for SQLiteConverter
+@pytest.mark.parametrize(
+    "column_props,expected",
+    [
+        # INTEGER affinity tests
+        (
+            {
+                "COLUMN_NAME": "id",
+                "TYPE": "integer",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=64),
+        ),
+        (
+            {
+                "COLUMN_NAME": "big_id",
+                "TYPE": "bigint",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=64),
+        ),
+        (
+            {
+                "COLUMN_NAME": "unsigned_big_id",
+                "TYPE": "unsigned bigint",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=64),
+        ),
+        # REAL affinity tests
+        (
+            {
+                "COLUMN_NAME": "real_col",
+                "TYPE": "real",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": 22,
+                "NUMERIC_SCALE": None,
+            },
+            FloatType(bits=32),
+        ),
+        (
+            {
+                "COLUMN_NAME": "float_col",
+                "TYPE": "float",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": 53,
+                "NUMERIC_SCALE": None,
+            },
+            FloatType(bits=64),
+        ),
+        # TEXT affinity tests
+        (
+            {
+                "COLUMN_NAME": "text_col",
+                "TYPE": "text",
+                "CHARACTER_OCTET_LENGTH": 255,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            StringType(bytes_=255),
+        ),
+        (
+            {
+                "COLUMN_NAME": "varchar_col",
+                "TYPE": "varchar(100)",
+                "CHARACTER_OCTET_LENGTH": 100,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            StringType(bytes_=100),
+        ),
+        # BLOB affinity tests
+        (
+            {
+                "COLUMN_NAME": "blob_col",
+                "TYPE": "blob",
+                "CHARACTER_OCTET_LENGTH": 500,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            BytesType(bytes_=500),
+        ),
+        # NUMERIC affinity tests
+        (
+            {
+                "COLUMN_NAME": "numeric_col",
+                "TYPE": "numeric",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": 10,
+                "NUMERIC_SCALE": 5,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        (
+            {
+                "COLUMN_NAME": "decimal_col",
+                "TYPE": "decimal(10,5)",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": 10,
+                "NUMERIC_SCALE": 5,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        # Edge case tests
+        (
+            {
+                "COLUMN_NAME": "custom_col",
+                "TYPE": "customtype",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        (
+            {
+                "COLUMN_NAME": "no_type_col",
+                "TYPE": None,
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            BytesType(bytes_=2147483647),
+        ),
+        # Date and time
+        (
+            {
+                "COLUMN_NAME": "date_col",
+                "TYPE": "DATE",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        (
+            {
+                "COLUMN_NAME": "datetime_col",
+                "TYPE": "DATETIME",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        (
+            {
+                "COLUMN_NAME": "timestamp_col",
+                "TYPE": "TIMESTAMP",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+        (
+            {
+                "COLUMN_NAME": "time_col",
+                "TYPE": "TIME",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            UnionType(
+                types=[
+                    NullType(),
+                    IntType(bits=64),
+                    FloatType(bits=64),
+                    StringType(bytes_=2147483647),
+                    BytesType(bytes_=2147483647),
+                ]
+            ),
+        ),
+    ],
+)
+def test_sqlite_converter(column_props, expected):
+    result = SQLiteConverter()._parse_type(column_props)
+    assert result == expected

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -47,6 +47,16 @@ from recap.settings import RecapSettings
             ["http://example.com?query=value", "http://user:pass@example.com#fragment"],
             ["http://example.com?query=value", "http://example.com#fragment"],
         ),
+        # SQLite empty netloc
+        (
+            ["sqlite:///some/file.db"],
+            ["sqlite:///some/file.db"],
+        ),
+        # Complex SQLite
+        (
+            ["sqlite:///file:mem1?mode=memory&cache=shared&uri=true"],
+            ["sqlite:///file:mem1?mode=memory&cache=shared&uri=true"],
+        ),
     ],
 )
 def test_safe_urls(input_urls, expected_output):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1594,3 +1594,49 @@ def test_struct_type_validate():
 
     with pytest.raises(ValueError):
         invalid_struct.validate()
+
+
+def test_make_nullable_of_union():
+    union_type = UnionType(
+        types=[
+            IntType(bits=32),
+            StringType(bytes_=50),
+        ]
+    )
+    assert union_type.make_nullable() == UnionType(
+        types=[
+            NullType(),
+            IntType(bits=32),
+            StringType(bytes_=50),
+        ],
+        default=None,
+        doc=None,
+    )
+
+
+def test_make_nullable_of_nullable():
+    union_type = UnionType(
+        types=[
+            NullType(),
+            IntType(bits=32),
+        ],
+        default=None,
+    )
+    assert union_type.make_nullable() == UnionType(
+        types=[
+            NullType(),
+            IntType(bits=32),
+        ],
+        default=None,
+    )
+
+
+
+def test_make_nullable_of_default_none():
+    union_type = NullType(default=None)
+    assert union_type.make_nullable() == UnionType(
+        types=[
+            NullType(),
+        ],
+        default=None,
+    )

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1631,7 +1631,6 @@ def test_make_nullable_of_nullable():
     )
 
 
-
 def test_make_nullable_of_default_none():
     union_type = NullType(default=None)
     assert union_type.make_nullable() == UnionType(


### PR DESCRIPTION
Recap can now read SQLite schemas as Recap types. SQLite's schema system is
somewhat strange. Some notes:

1. Any column can store any type.
2. SQLite has 5 storage classes (null, int, real, text, blob).
3. STRICT forces column types to be the storage types.
4. non-STRICT tables allow any strings for column types.
5. non-STRICT column types are hints to coerce types as they're written to disk.
6. Parenthesis in types (e.g. DOUBLE(6, 2)) are ignored by SQLite.

See https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes for more
details.

With all of this in mind, Recap's SQLiteConverter works according to SQLite's
affinity rules. This means:

1. Unknown types are treated as "ANY", which is a union of all storage types.
2. SQLiteConverter pays attention to precision/scale for REAL, etc.
3. SQLiteConverter pays attention to lengths for VARCHAR(255), etc.
4. SQLiteConverter treats date, datetime, time, and timestamp as ANY types.

Closes https://github.com/recap-build/recap/issues/418