### PR TITLE
Support python 3.11

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "bigquery", "hive", "json", "kafka", "proto", "style", "tests", "app", "all"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:5e027ac44661c105aab6e8bbf6fe474e9bd5902516812468547afefbd733e0e9"
+strategy = ["cross_platform"]
+lock_version = "4.4.1"
+content_hash = "sha256:71ffb28e1c32b2ff686a732d37fc1ab68fa35a53c17cad29d69c0e0fb7c6286f"
 
 [[package]]
 name = "annotated-types"
@@ -303,12 +302,12 @@ files = [
 
 [[package]]
 name = "dill"
-version = "0.3.6"
-requires_python = ">=3.7"
-summary = "serialize all of python"
+version = "0.3.8"
+requires_python = ">=3.8"
+summary = "serialize all of Python"
 files = [
-    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
-    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
+    {file = "dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"},
+    {file = "dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"},
 ]
 
 [[package]]
@@ -417,24 +416,6 @@ files = [
 ]
 
 [[package]]
-name = "google-api-core"
-version = "2.11.1"
-extras = ["grpc"]
-requires_python = ">=3.7"
-summary = "Google API client core library"
-dependencies = [
-    "google-api-core==2.11.1",
-    "grpcio-status<2.0.dev0,>=1.33.2",
-    "grpcio-status<2.0.dev0,>=1.49.1; python_version >= \"3.11\"",
-    "grpcio<2.0dev,>=1.33.2",
-    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
-]
-files = [
-    {file = "google-api-core-2.11.1.tar.gz", hash = "sha256:25d29e05a0058ed5f19c61c0a78b1b53adea4d9364b464d014fbda941f6d1c9a"},
-    {file = "google_api_core-2.11.1-py3-none-any.whl", hash = "sha256:d92a5a92dc36dd4f4b9ee4e55528a90e432b059f93aee6ad857f9de8cc7ae94a"},
-]
-
-[[package]]
 name = "google-auth"
 version = "2.22.0"
 requires_python = ">=3.6"
@@ -453,24 +434,20 @@ files = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.11.3"
+version = "3.17.2"
 requires_python = ">=3.7"
 summary = "Google BigQuery API client library"
 dependencies = [
-    "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5",
+    "google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5",
     "google-cloud-core<3.0.0dev,>=1.6.0",
     "google-resumable-media<3.0dev,>=0.6.0",
-    "grpcio<2.0dev,>=1.47.0",
-    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
     "packaging>=20.0.0",
-    "proto-plus<2.0.0dev,>=1.15.0",
-    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
     "python-dateutil<3.0dev,>=2.7.2",
     "requests<3.0.0dev,>=2.21.0",
 ]
 files = [
-    {file = "google-cloud-bigquery-3.11.3.tar.gz", hash = "sha256:d4585be9e76c984ec83ef290ebeff17562d2c9f2f4f84d3015d9b7b27b499a9d"},
-    {file = "google_cloud_bigquery-3.11.3-py2.py3-none-any.whl", hash = "sha256:266ba1ddd213b2454c1e4a92ae647813b783128078eb48dda4c0b443c5057e29"},
+    {file = "google-cloud-bigquery-3.17.2.tar.gz", hash = "sha256:6e1cf669a40e567ab3289c7b5f2056363da9fcb85d9a4736ee90240d4a7d84ea"},
+    {file = "google_cloud_bigquery-3.17.2-py2.py3-none-any.whl", hash = "sha256:cdadf5283dca55a1a350bacf8c8a7466169d3cf46c5a0a3abc5e9aa0b0a51dee"},
 ]
 
 [[package]]
@@ -555,48 +532,6 @@ dependencies = [
 files = [
     {file = "googleapis-common-protos-1.59.1.tar.gz", hash = "sha256:b35d530fe825fb4227857bc47ad84c33c809ac96f312e13182bdeaa2abe1178a"},
     {file = "googleapis_common_protos-1.59.1-py2.py3-none-any.whl", hash = "sha256:0cbedb6fb68f1c07e18eb4c48256320777707e7d0c55063ae56c15db3224a61e"},
-]
-
-[[package]]
-name = "grpcio"
-version = "1.56.0"
-requires_python = ">=3.7"
-summary = "HTTP/2-based RPC framework"
-files = [
-    {file = "grpcio-1.56.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fb34ace11419f1ae321c36ccaa18d81cd3f20728cd191250be42949d6845bb2d"},
-    {file = "grpcio-1.56.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:008767c0aed4899e657b50f2e0beacbabccab51359eba547f860e7c55f2be6ba"},
-    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:17f47aeb9be0da5337f9ff33ebb8795899021e6c0741ee68bd69774a7804ca86"},
-    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43c50d810cc26349b093bf2cfe86756ab3e9aba3e7e681d360930c1268e1399a"},
-    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187b8f71bad7d41eea15e0c9812aaa2b87adfb343895fffb704fb040ca731863"},
-    {file = "grpcio-1.56.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:881575f240eb5db72ddca4dc5602898c29bc082e0d94599bf20588fb7d1ee6a0"},
-    {file = "grpcio-1.56.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c243b158dd7585021d16c50498c4b2ec0a64a6119967440c5ff2d8c89e72330e"},
-    {file = "grpcio-1.56.0-cp310-cp310-win32.whl", hash = "sha256:8b3b2c7b5feef90bc9a5fa1c7f97637e55ec3e76460c6d16c3013952ee479cd9"},
-    {file = "grpcio-1.56.0-cp310-cp310-win_amd64.whl", hash = "sha256:03a80451530fd3b8b155e0c4480434f6be669daf7ecba56f73ef98f94222ee01"},
-    {file = "grpcio-1.56.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:64bd3abcf9fb4a9fa4ede8d0d34686314a7075f62a1502217b227991d9ca4245"},
-    {file = "grpcio-1.56.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:fdc3a895791af4addbb826808d4c9c35917c59bb5c430d729f44224e51c92d61"},
-    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:4f84a6fd4482e5fe73b297d4874b62a535bc75dc6aec8e9fe0dc88106cd40397"},
-    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14e70b4dda3183abea94c72d41d5930c333b21f8561c1904a372d80370592ef3"},
-    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b5ce42a5ebe3e04796246ba50357f1813c44a6efe17a37f8dc7a5c470377312"},
-    {file = "grpcio-1.56.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:8219f17baf069fe8e42bd8ca0b312b875595e43a70cabf397be4fda488e2f27d"},
-    {file = "grpcio-1.56.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:defdd14b518e6e468466f799aaa69db0355bca8d3a5ea75fb912d28ba6f8af31"},
-    {file = "grpcio-1.56.0-cp311-cp311-win32.whl", hash = "sha256:50f4daa698835accbbcc60e61e0bc29636c0156ddcafb3891c987e533a0031ba"},
-    {file = "grpcio-1.56.0-cp311-cp311-win_amd64.whl", hash = "sha256:59c4e606993a47146fbeaf304b9e78c447f5b9ee5641cae013028c4cca784617"},
-    {file = "grpcio-1.56.0.tar.gz", hash = "sha256:4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2"},
-]
-
-[[package]]
-name = "grpcio-status"
-version = "1.56.0"
-requires_python = ">=3.6"
-summary = "Status proto mapping for gRPC"
-dependencies = [
-    "googleapis-common-protos>=1.5.5",
-    "grpcio>=1.56.0",
-    "protobuf>=4.21.6",
-]
-files = [
-    {file = "grpcio-status-1.56.0.tar.gz", hash = "sha256:9eca0b2dcda0782d3702df225918efd6d820f75f93cd5c51c7fb6a4ffbfea12c"},
-    {file = "grpcio_status-1.56.0-py3-none-any.whl", hash = "sha256:e5f101c96686e9d4e94a114567960fdb00052aa3c818b029745e3db37dc9c613"},
 ]
 
 [[package]]
@@ -855,19 +790,6 @@ summary = "plugin and hook calling mechanisms for python"
 files = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
-]
-
-[[package]]
-name = "proto-plus"
-version = "1.22.3"
-requires_python = ">=3.6"
-summary = "Beautiful, Pythonic protocol buffers."
-dependencies = [
-    "protobuf<5.0.0dev,>=3.19.0",
-]
-files = [
-    {file = "proto-plus-1.22.3.tar.gz", hash = "sha256:fdcd09713cbd42480740d2fe29c990f7fbd885a67efc328aa8be6ee3e9f76a6b"},
-    {file = "proto_plus-1.22.3-py3-none-any.whl", hash = "sha256:a49cd903bc0b6ab41f76bf65510439d56ca76f868adf0274e738bfdd096894df"},
 ]
 
 [[package]]
@@ -1153,6 +1075,7 @@ dependencies = [
     "colorama>=0.4.5; sys_platform == \"win32\"",
     "dill>=0.2; python_version < \"3.11\"",
     "dill>=0.3.6; python_version >= \"3.11\"",
+    "dill>=0.3.7; python_version >= \"3.12\"",
     "isort<6,>=4.2.5",
     "mccabe<0.8,>=0.6",
     "platformdirs>=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ hive = [
     "pymetastore>=0.2.0",
 ]
 bigquery = [
-    "google-cloud-bigquery>=3.11.3",
+    "google-cloud-bigquery>=3.17.2",
 ]
 json = [
     "referencing>=0.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ authors = [
 ]
 dependencies = [
 ]
-# <= 3.11 for python-bigquery
-requires-python = ">=3.10, <=3.11"
+requires-python = ">=3.10, <=3.12"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = [


### PR DESCRIPTION
With https://github.com/googleapis/python-bigquery/pull/1736 released in version [3.14.0](https://github.com/googleapis/python-bigquery/pull/1709) of bigquery, python 3.11 is supported, so recap should also be able to support it.


Bigquery [changelog here](https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md).

Also may want to update the [dockerfile base](https://github.com/recap-build/recap/blob/4f6f0d41369be3c1da4f778b9951deb09645a4a4/Dockerfile#L2) and add 3.11 to the [matrix of ci tested versions](https://github.com/recap-build/recap/blob/6ae133f9926cedb82bfcbeaeb9e70f5f8e785395/.github/workflows/ci.yaml#L15) (4 locations total).