### PR TITLE
Add Python 3.11 to built matrix and Docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       # Publish to PyPI
       - name: Publish to PyPI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python base image
-FROM python:3.10
+FROM python:3.11
 
 ARG RECAP_VERSION
 


### PR DESCRIPTION
After bumping the pyproject.toml to support 3.11, the tests have now been updated to test both 3.10 and 3.11 in the build matrix. We're now using 3.11 in the Docker file.