### PR TITLE
Add UnknownType and use in converters

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -16,6 +16,7 @@ from recap.types import (
     StringType,
     StructType,
     UnionType,
+    UnknownType,
 )
 
 
@@ -147,7 +148,7 @@ class AvroConverter:
                 # meaning from other types.
                 avro_schema.pop("aliases", None)
             case _:
-                raise ValueError(f"Unsupported Recap type: {recap_type}")
+                avro_schema["type"] = "unknown"
 
         if len(avro_schema) == 1 and isinstance(avro_schema["type"], str):
             # Convert {"type": "type"} to "type"
@@ -352,7 +353,7 @@ class AvroConverter:
                 # Short circuit so we don't re-register aliases for nested types
                 return return_type
             case _:
-                raise ValueError(f"Unsupported Avro schema: {avro_schema}")
+                return UnknownType(**extra_attrs)
 
         if return_type.alias is not None:
             self.registry.register_alias(return_type)
@@ -431,4 +432,4 @@ class AvroConverter:
                     **extra_attrs,
                 )
             case _:
-                raise ValueError(f"Unsupported Avro logical type: {logical_type}")
+                return UnknownType(**extra_attrs)

--- a/recap/converters/bigquery.py
+++ b/recap/converters/bigquery.py
@@ -10,6 +10,7 @@ from recap.types import (
     ListType,
     StringType,
     StructType,
+    UnknownType,
 )
 
 
@@ -69,7 +70,7 @@ class BigQueryConverter:
                         scale=field.scale or 0,
                     )
                 case _:
-                    raise ValueError(f"Unrecognized field type: {field.field_type}")
+                    field_type = UnknownType()
 
             if field.mode == "REPEATED":
                 field_type = ListType(field_type)

--- a/recap/converters/hive_metastore.py
+++ b/recap/converters/hive_metastore.py
@@ -26,6 +26,7 @@ from recap.types import (
     StringType,
     StructType,
     UnionType,
+    UnknownType,
 )
 
 
@@ -160,7 +161,7 @@ class HiveMetastoreConverter:
                     **extra_attrs,
                 )
             case _:
-                raise ValueError(f"Unsupported type: {htype}")
+                recap_type = UnknownType(**extra_attrs)
 
         if not isinstance(recap_type, UnionType) and not isinstance(
             recap_type,

--- a/recap/converters/mysql.py
+++ b/recap/converters/mysql.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from recap.converters.dbapi import DbapiConverter
-from recap.types import BytesType, FloatType, IntType, RecapType, StringType
+from recap.types import BytesType, FloatType, IntType, RecapType, StringType, UnknownType
 
 
 class MysqlConverter(DbapiConverter):
@@ -77,6 +77,6 @@ class MysqlConverter(DbapiConverter):
                 signed=False,
             )  # Years are typically 2-byte values
         else:
-            raise ValueError(f"Unknown data type: {data_type}")
+            base_type = UnknownType()
 
         return base_type

--- a/recap/converters/postgresql.py
+++ b/recap/converters/postgresql.py
@@ -15,6 +15,7 @@ from recap.types import (
     RecapTypeRegistry,
     StringType,
     UnionType,
+    UnknownType,
 )
 
 MAX_FIELD_SIZE = 1073741824
@@ -144,7 +145,7 @@ class PostgresqlConverter(DbapiConverter):
                 symbols=column_props["ENUM_VALUES"],
             )
         else:
-            raise ValueError(f"Unknown data type: {data_type}")
+            base_type = UnknownType()
 
         return base_type
 

--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -28,6 +28,7 @@ from recap.types import (
     StringType,
     StructType,
     UnionType,
+    UnknownType,
 )
 
 DEFAULT_NAMESPACE = "_root"
@@ -486,4 +487,4 @@ class ProtobufConverter:
                 # Always start from the root since Recap namespaces are always root-based.
                 return Field(field_name, field_number, "." + alias)
             case _:
-                raise ValueError(f"Invalid RecapType: {recap_type}")
+                return UnknownType()

--- a/recap/converters/snowflake.py
+++ b/recap/converters/snowflake.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from recap.converters.dbapi import DbapiConverter
-from recap.types import BoolType, BytesType, FloatType, IntType, RecapType, StringType
+from recap.types import BoolType, BytesType, FloatType, IntType, RecapType, StringType, UnknownType
 
 
 class SnowflakeConverter(DbapiConverter):
@@ -75,6 +75,6 @@ class SnowflakeConverter(DbapiConverter):
             unit = self._get_time_unit(params) or "nanosecond"
             base_type = IntType(bits=32, logical="build.recap.Time", unit=unit)
         else:
-            raise ValueError(f"Unknown data type: {data_type}")
+            base_type = UnknownType()
 
         return base_type

--- a/recap/converters/sqlite.py
+++ b/recap/converters/sqlite.py
@@ -10,6 +10,7 @@ from recap.types import (
     RecapType,
     StringType,
     UnionType,
+    UnknownType,
 )
 
 # SQLite's maximum length is 2^31-1 bytes, or 2147483647 bytes.
@@ -59,9 +60,7 @@ class SQLiteConverter(DbapiConverter):
                     ]
                 )
             case _:
-                raise ValueError(
-                    f"Unsupported `{column_type}` type for `{column_name}`"
-                )
+                return UnknownType()
 
     @staticmethod
     def get_affinity(column_type: str | None) -> SQLiteAffinity:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -20,6 +20,7 @@ from recap.types import (
     StringType,
     StructType,
     UnionType,
+    UnknownType,
     from_dict,
     to_dict,
 )
@@ -194,6 +195,26 @@ def test_from_dict_raises_for_missing_type():
     with pytest.raises(AssertionError):
         from_dict({"alias": "alias"})
 
+def test_from_dict_unknown_type():
+    unknown_type_dict = {
+        "type": "unknown",
+        "name": "bleh",
+    }
+    recap_type = from_dict(unknown_type_dict)
+    assert isinstance(recap_type, UnknownType)
+    assert recap_type.extra_attrs["name"] == "bleh"
+    assert recap_type.description == "Unknown or unsupported type"
+
+def test_from_dict_unknown_with_description_type():
+    unknown_type_dict = {
+        "type": "unknown",
+        "name": "bleh",
+        "description": "This is a description",
+    }
+    recap_type = from_dict(unknown_type_dict)
+    assert isinstance(recap_type, UnknownType)
+    assert recap_type.extra_attrs["name"] == "bleh"
+    assert recap_type.description == "This is a description"
 
 def test_from_dict_self_referencing_structure():
     # define the test_dict with the self-referencing structure


### PR DESCRIPTION
Addresses https://github.com/recap-build/recap/issues/429

Adds a new type `UnknownType` for situations where converters can't figure out an appropriate existing recap type.

This does not have comprehensive test cases and I'm not sure this is the right way to go for all these converters, but I wanted to get started on this so we can discuss and collaborate on it.

Made a PR for the website/json schema update: https://github.com/recap-build/recap-website/pull/16

## Validation

We will need to add a bunch of tests for the converters, parser, and for the JSON schema validation.