### PR TITLE
Detect unsigned integers in MySQL converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recap-core"
-version = "0.12.1"
+version = "0.12.2"
 description = "Recap reads and writes schemas from web services, databases, and schema registries in a standard format"
 authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},

--- a/recap/converters/mysql.py
+++ b/recap/converters/mysql.py
@@ -14,7 +14,13 @@ class MysqlConverter(DbapiConverter):
         column_type = column_props.get("COLUMN_TYPE", "").lower()
 
         # For unsigned, column type will be something like 'bigint unsigned'
-        signed = re.match(r".*\s+unsigned(\s+|$)", column_type.decode() if isinstance(column_type, bytes) else column_type) is None
+        signed = (
+            re.match(
+                r".*\s+unsigned(\s+|$)",
+                column_type.decode() if isinstance(column_type, bytes) else column_type,
+            )
+            is None
+        )
 
         if data_type == "bigint":
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html

--- a/recap/converters/mysql.py
+++ b/recap/converters/mysql.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from recap.converters.dbapi import DbapiConverter
@@ -10,22 +11,26 @@ class MysqlConverter(DbapiConverter):
         octet_length = column_props["CHARACTER_OCTET_LENGTH"]
         precision = column_props["NUMERIC_PRECISION"]
         scale = column_props["NUMERIC_SCALE"]
+        column_type = column_props.get("COLUMN_TYPE", "").lower()
+
+        # For unsigned, column type will be something like 'bigint unsigned'
+        signed = re.match(r".*\s+unsigned(\s+|$)", column_type.decode() if isinstance(column_type, bytes) else column_type) is None
 
         if data_type == "bigint":
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
-            base_type = IntType(bits=64, signed=True)
+            base_type = IntType(bits=64, signed=signed)
         elif data_type in ["int", "integer"]:
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
-            base_type = IntType(bits=32, signed=True)
+            base_type = IntType(bits=32, signed=signed)
         elif data_type == "mediumint":
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
-            base_type = IntType(bits=24, signed=True)
+            base_type = IntType(bits=24, signed=signed)
         elif data_type == "smallint":
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
-            base_type = IntType(bits=16, signed=True)
+            base_type = IntType(bits=16, signed=signed)
         elif data_type == "tinyint":
             # https://dev.mysql.com/doc/refman/8.0/en/integer-types.html
-            base_type = IntType(bits=8, signed=True)
+            base_type = IntType(bits=8, signed=signed)
         elif data_type == "double" or (data_type == "float" and precision > 23):
             # https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html
             base_type = FloatType(bits=64)

--- a/tests/integration/clients/test_mysql.py
+++ b/tests/integration/clients/test_mysql.py
@@ -36,6 +36,9 @@ class TestMySqlClient:
                 test_float FLOAT,
                 test_double DOUBLE PRECISION,
                 test_real REAL,
+                test_bigint_unsigned BIGINT UNSIGNED,
+                test_integer_unsigned INTEGER UNSIGNED,
+                test_smallint_unsigned SMALLINT UNSIGNED,
                 test_boolean BOOLEAN,
                 test_text TEXT,
                 test_char CHAR(10),
@@ -110,6 +113,21 @@ class TestMySqlClient:
                 default=None,
                 name="test_real",
                 types=[NullType(), FloatType(bits=64)],
+            ),
+            UnionType(
+                default=None,
+                name="test_bigint_unsigned",
+                types=[NullType(), IntType(bits=64, signed=False)],
+            ),
+            UnionType(
+                default=None,
+                name="test_integer_unsigned",
+                types=[NullType(), IntType(bits=32, signed=False)],
+            ),
+            UnionType(
+                default=None,
+                name="test_smallint_unsigned",
+                types=[NullType(), IntType(bits=16, signed=False)],
             ),
             UnionType(
                 default=None,

--- a/tests/unit/converters/test_mysql.py
+++ b/tests/unit/converters/test_mysql.py
@@ -10,6 +10,7 @@ from recap.types import BytesType, FloatType, IntType, StringType
         (
             {
                 "DATA_TYPE": "bigint",
+                "COLUMN_TYPE": "bigint",
                 "CHARACTER_OCTET_LENGTH": None,
                 "NUMERIC_PRECISION": None,
                 "NUMERIC_SCALE": None,
@@ -19,6 +20,7 @@ from recap.types import BytesType, FloatType, IntType, StringType
         (
             {
                 "DATA_TYPE": "int",
+                "COLUMN_TYPE": "int",
                 "CHARACTER_OCTET_LENGTH": None,
                 "NUMERIC_PRECISION": None,
                 "NUMERIC_SCALE": None,
@@ -87,6 +89,66 @@ from recap.types import BytesType, FloatType, IntType, StringType
                 "NUMERIC_SCALE": None,
             },
             FloatType(bits=32),
+        ),
+        (
+            {
+                "DATA_TYPE": "bigint",
+                "COLUMN_TYPE": "bigint unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=64, signed=False),
+        ),
+        (
+            {
+                "DATA_TYPE": "int",
+                "COLUMN_TYPE": "int unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=32, signed=False),
+        ),
+        (
+            {
+                "DATA_TYPE": "integer",
+                "COLUMN_TYPE": "int unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=32, signed=False),
+        ),
+        (
+            {
+                "DATA_TYPE": "mediumint",
+                "COLUMN_TYPE": "mediumint unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=24, signed=False),
+        ),
+        (
+            {
+                "DATA_TYPE": "smallint",
+                "COLUMN_TYPE": "smallint unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=16, signed=False),
+        ),
+        (
+            {
+                "DATA_TYPE": "tinyint",
+                "COLUMN_TYPE": "tinyint unsigned",
+                "CHARACTER_OCTET_LENGTH": None,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_SCALE": None,
+            },
+            IntType(bits=8, signed=False),
         ),
         (
             {


### PR DESCRIPTION
Adds support for unsigned integer values to the MySQL converter

> UNSIGNED, if specified, disallows negative values. The UNSIGNED attribute is deprecated for columns of type [FLOAT](https://dev.mysql.com/doc/refman/8.4/en/floating-point-types.html) (and any synonyms) and you should expect support for it to be removed in a future version of MySQL. Consider using a simple CHECK constraint instead for such columns.

https://dev.mysql.com/doc/refman/8.4/en/numeric-type-syntax.html