### PR TITLE
update hive-metastore-standalone reference from recap-build to criccomini

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -86,6 +86,6 @@ services:
       retries: 5
 
   hive-metastore:
-    image: ghcr.io/recap-build/hive-metastore-standalone:latest
+    image: ghcr.io/criccomini/hive-metastore-standalone:latest
     ports:
       - "9083:9083"


### PR DESCRIPTION
Failure [here](https://github.com/gabledata/recap/actions/runs/14249446957/job/39938575560?pr=431#step:3:21) in tests

```
Error: compose up failed {"exitCode":18,"err":"time=\"2025-04-03T17:50:04Z\" level=warning msg=\"/home/runner/work/recap/recap/tests/docker-compose.yml: `version` is obsolete\"\n hive-metastore Pulling \n postgres Pulling \n kafka Pulling \n zookeeper Pulling \n mysql Pulling \n schema-registry Pulling \n bigquery Pulling \n hive-metastore Error Head \"[https://ghcr.io/v2/recap-build/hive-metastore-standalone/manifests/latest\](https://ghcr.io/v2/recap-build/hive-metastore-standalone/manifests/latest/)": denied\n mysql Error context canceled\n postgres Error context canceled\n zookeeper Error context canceled\n bigquery Error context canceled\n kafka Error context canceled\n schema-registry Error context canceled\nError response from daemon: Head \"[https://ghcr.io/v2/recap-build/hive-metastore-standalone/manifests/latest\](https://ghcr.io/v2/recap-build/hive-metastore-standalone/manifests/latest/)": denied\n","out":""}
```

Because the repo [was moved](https://github.com/gabledata/recap/pull/431#issuecomment-2828165592).


This updates the reference. 