### PR TITLE
Improve handling of single item type arrays in JSON schema

### DIFF
--- a/recap/converters/json_schema.py
+++ b/recap/converters/json_schema.py
@@ -72,7 +72,14 @@ class JSONSchemaConverter:
         match json_schema:
             # Special handling for "type" defined as a list of strings like
             # {"type": ["string", "boolean"]}
+            # https://json-schema.org/understanding-json-schema/reference/type#type-specific-keywords
             case {"type": list(type_list)}:
+                # Special handling for single item type lists
+                if len(type_list) == 1:
+                    # Convert the type array to the single type, then re-parse the entire JSON
+                    # schema. This covers cases like {"type": ["array"], "items": ...}
+                    json_schema = {**json_schema, "type": type_list[0]}
+                    return self._parse(json_schema, alias_strategy)
                 types = [self._parse(s, alias_strategy) for s in type_list]
                 return UnionType(types, **extra_attrs)
             case {"type": "object", "properties": properties}:

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -127,6 +127,42 @@ def test_union_types():
     ]
 
 
+def test_single_type_in_array():
+    json_schema = """
+    {
+        "type": "object",
+        "properties": {
+            "stringtype":  {"type": ["string"]}
+        },
+        "required": ["stringtype"]
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == [StringType(name="stringtype")]
+
+
+def test_single_array_type_in_array():
+    json_schema = """
+    {
+        "type": "object",
+        "properties": {
+            "stringarraytype":  
+            {
+                "type": ["array"], 
+                "items": { "type": ["string"] }
+            }
+        },
+        "required": ["stringarraytype"]
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == [ListType(StringType(), name="stringarraytype")]
+
+
 def test_nested_objects():
     json_schema = """
     {


### PR DESCRIPTION
# Summary

cc @criccomini

Small change to the `JSONSchemaConverter` to better handle `"type"` defined as a single element array (`{"type": ["string"]}`). This has two effects:

* Directly return the type in the array instead of a single type union, which was technically correct but annoying
* Handle edge case where `type` is a single element array, and the object contains additional properties specific to that type:
    ```
    {
        "type": ["array"], 
        "items": { "type": ["string"] }
    }
    ```
    The [JSON schema spec](https://json-schema.org/understanding-json-schema/reference/type#type-specific-keywords) is kind of ambiguous here as it only covers the case where the array has more than one value
    > An array of strings. When type is used as an array, it contains more than one string specifying the types mentioned above. In this case, the instance data is valid if it matches any of the given types.
   
    but the JSON schema validator I tried & the one used by the tests both say it's valid 🤷 