### PR TITLE
Handle object with missing properties in JSON schema

### DIFF
--- a/recap/converters/json_schema.py
+++ b/recap/converters/json_schema.py
@@ -82,7 +82,8 @@ class JSONSchemaConverter:
                     return self._parse(json_schema, alias_strategy)
                 types = [self._parse(s, alias_strategy) for s in type_list]
                 return UnionType(types, **extra_attrs)
-            case {"type": "object", "properties": properties}:
+            case {"type": "object"}:
+                properties = json_schema.get("properties", {})
                 fields = []
                 for name, prop in properties.items():
                     field = self._parse(prop, alias_strategy)

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -269,6 +269,36 @@ def test_required_properties():
     ]
 
 
+def test_object_no_properties():
+    json_schema = """
+    {
+        "type": "object"
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == []
+
+
+def test_nested_object_no_properties():
+    json_schema = """
+    {
+        "type": "object",
+        "properties": {
+            "nested_no_properties": {
+                "type": "object"
+            }
+        },
+        "required": ["nested_no_properties"]
+    }
+    """
+    Draft202012Validator.check_schema(loads(json_schema))
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
+    assert isinstance(struct_type, StructType)
+    assert struct_type.fields == [StructType(fields=[], name="nested_no_properties")]
+
+
 def test_doc_attribute():
     json_schema = """
     {


### PR DESCRIPTION
# Summary

Small change to the `JSONSchemaConverter` to handle objects with no "properties" keyword, which is technically valid

```json
{
    "type": "object"
}
```

 The output is the same as an object with `"properties": {}` - a `StructType` with an empty fields array