### PR TITLE
Pin confluent images in test docker-compose file

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - "9050:9050"
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.9.2
     ports:
       - "2181:2181"
     environment:
@@ -52,7 +52,7 @@ services:
       retries: 5
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.9.2
     ports:
       - "9092:9092"
     environment:
@@ -68,7 +68,7 @@ services:
       retries: 5
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:latest
+    image: confluentinc/cp-schema-registry:7.9.2
     ports:
       - "8081:8081"
     environment:


### PR DESCRIPTION
# Summary

Temporarily pins the `confluentinc` images in the integration test docker-compose file. Confluent recently [released version 8 of their images](https://hub.docker.com/r/confluentinc/cp-schema-registry/tags?ordering=name&name=8.0) which fail to start using the current config. Pinning to the latest 7.* version to unblock tests

I'll rebase https://github.com/gabledata/recap/pull/434 once this is in